### PR TITLE
Add option to pass the --yarn flag for the `vsce package` invocation

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,9 +31,10 @@ program.command('install-vsix')
     .description('Install extension from vsix file into test instance of VSCode')
     .option('-s, --storage <storage>', 'Use this folder for all test resources')
     .option('-f, --vsix_file <file>', 'vsix file containing the extension')
+    .option('-y, --yarn', 'Use yarn to build the extension via vsce instead of npm', false)
     .action((cmd) => {
         const extest = new ExTester(cmd.storage);
-        extest.installVsix(cmd.vsix_file);
+        extest.installVsix({vsixFile: cmd.vsix_file, useYarn: cmd.yarn});
     });
 
 program.command('setup-tests')
@@ -41,9 +42,10 @@ program.command('setup-tests')
     .option('-s, --storage <storage>', 'Use this folder for all test resources')
     .option('-c, --code_version <version>', 'Version of VSCode to download')
     .option('-t, --type <type>', 'Type of VSCode release (stable/insider)')
+    .option('-y, --yarn', 'Use yarn to build the extension via vsce instead of npm', false)
     .action(async (cmd) => {
         const extest = new ExTester(cmd.storage);
-        await extest.setupRequirements(cmd.code_version, cmd.type);
+        await extest.setupRequirements(cmd.code_version, cmd.type, cmd.yarn);
     });
 
 program.command('run-tests <testFiles>')
@@ -61,9 +63,10 @@ program.command('setup-and-run <testFiles>')
     .option('-c, --code_version <version>', 'Version of VSCode to download')
     .option('-t, --type <type>', 'Type of VSCode release (stable/insider)')
     .option('-o, --code_settings <settings.json>', 'Path to custom settings for VS Code json file')
+    .option('-y, --yarn', 'Use yarn to build the extension via vsce instead of npm', false)
     .action(async (testFiles, cmd) => {
         const extest = new ExTester(cmd.storage);
-        await extest.setupAndRunTests(cmd.code_version, cmd.type, testFiles, cmd.code_settings);
+        await extest.setupAndRunTests(cmd.code_version, cmd.type, testFiles, cmd.code_settings, cmd.yarn);
     });
 
 program.parse(process.argv);

--- a/src/extester.ts
+++ b/src/extester.ts
@@ -79,10 +79,11 @@ export class ExTester {
     /**
      * Install the extension into the test instance of VS Code
      * @param vsixFile path to extension .vsix file. If not set, default vsce path will be used
+     * @param useYarn when true run `vsce package` with the `--yarn` flag
      */
-    installVsix(vsixFile?: string): void {
+    installVsix({vsixFile, useYarn}: {vsixFile?: string, useYarn?: boolean} = {}): void {
         if (!vsixFile) {
-            this.code.packageExtension();
+            this.code.packageExtension(useYarn);
         } else if (!fs.existsSync(vsixFile)) {
             throw new Error(`File ${vsixFile} does not exist`);
         }
@@ -106,12 +107,13 @@ export class ExTester {
      * 
      * @param vscodeVersion version of VSCode to test against, default latest
      * @param vscodeStream whether to use stable or insiders build, default stable
+     * @param useYarn when true run `vsce package` with the `--yarn` flag
      */
-    async setupRequirements(vscodeVersion: string = 'latest', vscodeStream: string = 'stable'): Promise<void> {
+    async setupRequirements(vscodeVersion: string = 'latest', vscodeStream: string = 'stable', useYarn?: boolean): Promise<void> {
         const quality = vscodeStream === 'insider' ? ReleaseQuality.Insider : ReleaseQuality.Stable;
         await this.downloadCode(vscodeVersion, quality);
         await this.downloadChromeDriver(vscodeVersion, vscodeStream);
-        this.installVsix();
+        this.installVsix({useYarn});
     }
 
     /**
@@ -121,9 +123,10 @@ export class ExTester {
      * @param vscodeStream whether to use stable or insiders build, default stable
      * @param testFilesPattern glob pattern for test files to run
      * @param settings path to a custom vscode settings json file
+     * @param useYarn when true run `vsce package` with the `--yarn` flag
      */
-    async setupAndRunTests(vscodeVersion: string = 'latest', vscodeStream: string = 'stable', testFilesPattern: string, settings: string = ''): Promise<void> {
-        await this.setupRequirements(vscodeVersion, vscodeStream);
+    async setupAndRunTests(vscodeVersion: string = 'latest', vscodeStream: string = 'stable', testFilesPattern: string, settings: string = '', useYarn?: boolean): Promise<void> {
+        await this.setupRequirements(vscodeVersion, vscodeStream, useYarn);
         this.runTests(testFilesPattern, vscodeVersion, vscodeStream, settings);
     }
 

--- a/src/util/codeUtil.ts
+++ b/src/util/codeUtil.ts
@@ -117,15 +117,16 @@ export class CodeUtil {
         child_process.execSync(command, { stdio: 'inherit' });
     }
 
-    packageExtension(): void {
+    packageExtension(useYarn?: boolean): void {
         // add vsce to process' path
         const binFolder = path.join(__dirname, '..', '..', 'node_modules', '.bin');
         const finalEnv: NodeJS.ProcessEnv = {};
         Object.assign(finalEnv, process.env);
         const key = process.platform === 'win32' ? 'Path' : 'PATH';
         finalEnv[key] = [binFolder, process.env[key]].join(path.delimiter);
+        const cliCall = `vsce package${useYarn ? ' --yarn' : ''}`;
 
-        child_process.execSync('vsce package', { stdio: 'inherit', env: finalEnv });
+        child_process.execSync(cliCall, { stdio: 'inherit', env: finalEnv });
     }
 
     /**


### PR DESCRIPTION
This fixes #22.

Unfortunately, I don't really know how to test this, thus I'm not sure if it actually works…