### PR TITLE
Add create method to input objects

### DIFF
--- a/src/webdriver/components/workbench/Workbench.ts
+++ b/src/webdriver/components/workbench/Workbench.ts
@@ -107,7 +107,7 @@ export class Workbench extends AbstractElement {
      */
     async openCommandPrompt(): Promise<QuickOpenBox> {
         await this.getDriver().actions().sendKeys(Key.F1).perform();
-        return new QuickOpenBox().wait();
+        return QuickOpenBox.create();
     }
 
     /**

--- a/src/webdriver/components/workbench/input/InputBox.ts
+++ b/src/webdriver/components/workbench/input/InputBox.ts
@@ -1,4 +1,5 @@
 import { Input, QuickPickItem } from "../../../../extester";
+import { until } from "selenium-webdriver";
 
 /**
  * Plain input box variation of the input page object
@@ -6,6 +7,15 @@ import { Input, QuickPickItem } from "../../../../extester";
 export class InputBox extends Input {
     constructor() {
         super(InputBox.locators.InputBox.constructor, InputBox.locators.Workbench.constructor);
+    }
+
+    /**
+     * Construct a new InputBox instance after waiting for its underlying element to exist
+     * Use when an input box is scheduled to appear.
+     */
+    static async create(): Promise<InputBox> {
+        await InputBox.driver.wait(until.elementLocated(InputBox.locators.InputBox.constructor), 5000);
+        return new InputBox().wait();
     }
 
     /**

--- a/src/webdriver/components/workbench/input/QuickOpenBox.ts
+++ b/src/webdriver/components/workbench/input/QuickOpenBox.ts
@@ -9,6 +9,15 @@ export class QuickOpenBox extends Input {
         super(QuickOpenBox.locators.QuickOpenBox.constructor, QuickOpenBox.locators.Workbench.constructor);
     }
 
+    /**
+     * Construct a new QuickOpenBox instance after waiting for its underlying element to exist
+     * Use when a quick open box is scheduled to appear.
+     */
+    static async create(): Promise<QuickOpenBox> {
+        await QuickOpenBox.driver.wait(until.elementLocated(QuickOpenBox.locators.QuickOpenBox.constructor));
+        return new QuickOpenBox().wait();
+    }
+
     async hasProgress(): Promise<boolean> {
         const klass = await this.findElement(QuickOpenBox.locators.QuickOpenBox.progress)
             .getAttribute('class');

--- a/test/test-project/src/test/bottomBar/problemsView-test.ts
+++ b/test/test-project/src/test/bottomBar/problemsView-test.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { Workbench, TextEditor, EditorView, ProblemsView, BottomBarPanel, MarkerType, VSBrowser, until, By, InputBox } from "vscode-extension-tester";
+import { Workbench, TextEditor, EditorView, ProblemsView, BottomBarPanel, MarkerType, InputBox } from "vscode-extension-tester";
 import { expect } from 'chai';
 
 describe('ProblemsView', () => {
@@ -10,8 +10,7 @@ describe('ProblemsView', () => {
     before(async function() {
         this.timeout(12000);
         await new Workbench().executeCommand('extest open file');
-        await VSBrowser.instance.driver.wait(until.elementLocated(By.className('quick-input-widget')));
-        const input = await new InputBox().wait();
+        const input = await InputBox.create();
         await input.setText(path.resolve(__dirname, '..', '..', '..', '..', 'resources', 'test-file.ts'));
         await input.confirm();
         await new Promise((res) => { setTimeout(res, 1000); });

--- a/test/test-project/src/test/editor/textEditor-test.ts
+++ b/test/test-project/src/test/editor/textEditor-test.ts
@@ -9,8 +9,7 @@ describe('ContentAssist', async () => {
     before(async function() {
         this.timeout(15000);
         await new Workbench().executeCommand('extest open file');
-        await VSBrowser.instance.driver.wait(until.elementLocated(By.className('quick-input-widget')));
-        const input = await new InputBox().wait();
+        const input = await InputBox.create();
         await input.setText(path.resolve(__dirname, '..', '..', '..', '..', 'resources', 'test-file.ts'));
         await input.confirm();
 
@@ -50,7 +49,7 @@ describe('TextEditor', () => {
         editor = new TextEditor(view, 'Untitled-1');
 
         await new StatusBar().openLanguageSelection();
-        const input = await new InputBox().wait();
+        const input = await InputBox.create();
         await input.setText('typescript');
         await input.confirm();
     });

--- a/test/test-project/src/test/statusBar/statusBar-test.ts
+++ b/test/test-project/src/test/statusBar/statusBar-test.ts
@@ -23,7 +23,7 @@ describe('StatusBar', () => {
 
     it('openLanguageSelection works', async () => {
         await bar.openLanguageSelection();
-        const input = await new InputBox().wait();
+        const input = await InputBox.create();
         expect(await input.getPlaceHolder()).equals('Select Language Mode');
         await input.cancel();
     });
@@ -35,7 +35,7 @@ describe('StatusBar', () => {
 
     it('openLineEndingSelection works', async () => {
         await bar.openLineEndingSelection();
-        const input = await new InputBox().wait();
+        const input = await InputBox.create();
         expect(await input.getPlaceHolder()).equals('Select End of Line Sequence');
         await input.cancel();
     });
@@ -47,7 +47,7 @@ describe('StatusBar', () => {
 
     it('openEncodingSelection works', async () => {
         await bar.openEncodingSelection();
-        const input = await new InputBox().wait();
+        const input = await InputBox.create();
         expect(await input.getPlaceHolder()).equals('Select File Encoding to Save with');
         await input.cancel();
     });
@@ -59,7 +59,7 @@ describe('StatusBar', () => {
 
     it('openIndentationSelection works', async () => {
         await bar.openIndentationSelection();
-        const input = await new InputBox().wait();
+        const input = await InputBox.create();
         expect(await input.getPlaceHolder()).equals('Select Action');
         await input.cancel();
     });
@@ -71,7 +71,7 @@ describe('StatusBar', () => {
 
     it('openLineSelection works', async () => {
         await bar.openLineSelection();
-        const input = await new QuickOpenBox().wait();
+        const input = await QuickOpenBox.create();
         expect(await input.isDisplayed()).is.true;
         await input.cancel();
     });

--- a/test/test-project/src/test/workbench/input-test.ts
+++ b/test/test-project/src/test/workbench/input-test.ts
@@ -77,7 +77,7 @@ describe('InputBox', () => {
     before(async () => {
         await new TitleBar().select('File', 'New File');
         await new StatusBar().openLanguageSelection();
-        input = await new InputBox().wait();
+        input = await InputBox.create();;
     });
 
     after(async() => {

--- a/test/test-project/src/test/workbench/workbench-test.ts
+++ b/test/test-project/src/test/workbench/workbench-test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { StatusBar, TitleBar, EditorView, InputBox, QuickOpenBox, Workbench } from 'vscode-extension-tester';
+import { EditorView, Workbench } from 'vscode-extension-tester';
 
 describe('Workbench', () => {
     let bench: Workbench;

--- a/test/test-project/src/test/xsideBar/sideBarView-test.ts
+++ b/test/test-project/src/test/xsideBar/sideBarView-test.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import { expect } from 'chai';
-import { SideBarView, ActivityBar, ViewTitlePart, Workbench, ViewItem, ViewContent, ViewSection, DefaultTreeSection, DefaultTreeItem, TextEditor, EditorView, until, By, InputBox } from "vscode-extension-tester";
+import { SideBarView, ActivityBar, ViewTitlePart, Workbench, ViewItem, ViewContent, ViewSection, DefaultTreeSection, DefaultTreeItem, TextEditor, EditorView, InputBox } from "vscode-extension-tester";
 
 describe('SideBarView', () => {
     let view: SideBarView;
@@ -47,8 +47,7 @@ describe('SideBarView', () => {
         before(async function() {
             this.timeout(6000);
             await new Workbench().executeCommand('extest open folder');
-            await view.getDriver().wait(until.elementLocated(By.className('quick-input-widget')));
-            const input = await new InputBox().wait();
+            const input = await InputBox.create();
             await input.setText(path.resolve(__dirname, '..', '..', '..', '..', 'resources', 'test-folder'));
             await input.confirm();
 


### PR DESCRIPTION
`create()` waits for the DOM to update and then constructs the page objects. Use as a way to safely wait for the input to appear.