### PR TITLE
Replace Quickpick#getText with getLabel and getDescription

### DIFF
--- a/src/webdriver/components/workbench/input/Input.ts
+++ b/src/webdriver/components/workbench/input/Input.ts
@@ -126,10 +126,21 @@ export class QuickPickItem extends AbstractElement {
     }
 
     /**
-     * Get the text of the quick pick item
+     * Get the label of the quick pick item
      */
-    async getText(): Promise<string> {
-        return await this.findElement(Input.locators.Input.quickPickText).getText();
+    async getLabel(): Promise<string> {
+        return this.findElement(Input.locators.Input.quickPickLabel).getText();
+    }
+
+    /**
+     * Get the description of the quick pick item
+     */
+    async getDescription(): Promise<string | undefined> {
+        try {
+            return await this.findElement(Input.locators.Input.quickPickDescription).getText();
+        } catch (err) {
+            return undefined;
+        }
     }
 
     /**

--- a/src/webdriver/locators/locators.ts
+++ b/src/webdriver/locators/locators.ts
@@ -258,7 +258,8 @@ export interface Locators {
         input: By
         quickPickIndex: (index: number) => By
         quickPickPosition: (index: number) => By
-        quickPickText: By
+        quickPickLabel: By,
+        quickPickDescription: By
     }
     InputBox: {
         constructor: By

--- a/src/webdriver/locators/versions/1.37.0.ts
+++ b/src/webdriver/locators/versions/1.37.0.ts
@@ -261,7 +261,8 @@ const input = {
         input: By.className('input'),
         quickPickIndex: (index: number) => By.xpath(`.//div[@role='treeitem' and @data-index='${index}']`),
         quickPickPosition: (index: number) => By.xpath(`.//div[@role='treeitem' and @aria-posinset='${index}']`),
-        quickPickText: By.className('monaco-highlighted-label')
+        quickPickLabel: By.className('label-name'),
+        quickPickDescription: By.className('label-description')
     },
     InputBox: {
         constructor: By.className('quick-input-widget'),

--- a/test/test-project/package.json
+++ b/test/test-project/package.json
@@ -38,6 +38,10 @@
 			{
 				"command": "extension.closeFolder",
 				"title": "Close Test Folder"
+			},
+			{
+				"command": "extension.test",
+				"title": "Test Command"
 			}
 		],
 		"views": {

--- a/test/test-project/src/extension.ts
+++ b/test/test-project/src/extension.ts
@@ -19,11 +19,15 @@ export function activate(context: vscode.ExtensionContext) {
 	let closeFolder = vscode.commands.registerCommand('extension.closeFolder', async () => {
 		vscode.workspace.updateWorkspaceFolders(0, 1);
 	});
+	let testCommand = vscode.commands.registerCommand('extension.test', async () => {
+		vscode.window.showQuickPick([{ label: 'TestLabel', description: 'Test Description' }]);
+	})
 
 	context.subscriptions.push(disposable);
 	context.subscriptions.push(openCommand);
 	context.subscriptions.push(openFolder);
 	context.subscriptions.push(closeFolder);
+	context.subscriptions.push(testCommand);
 
 	new TreeView(context);
 }

--- a/test/test-project/src/test/workbench/input-test.ts
+++ b/test/test-project/src/test/workbench/input-test.ts
@@ -55,8 +55,8 @@ describe('QuickPickItem', () => {
         item = picks[0];
     });
 
-    it('getText returns label', async () => {
-        const text = await item.getText();
+    it('getLabel returns label', async () => {
+        const text = await item.getLabel();
         expect(text).not.empty;
     });
 
@@ -68,6 +68,15 @@ describe('QuickPickItem', () => {
     it('select works', async () => {
         await item.select();
         expect(await input.isDisplayed()).is.false;
+    });
+
+    it('getDescription works', async function() {
+        this.timeout(4000);
+        await new Workbench().executeCommand('Test Command');
+        const inputbox = await InputBox.create();
+        const pick = (await inputbox.getQuickPicks())[0];
+        const desc = await pick.getDescription();
+        expect(desc).has.string('Test Description');
     });
 });
 


### PR DESCRIPTION
fix #59

getText will still be available but now will return all text contained in the element:
 - getLabel will now return what getText used to
 - getDescription will return the optional description of an item