### PR TITLE
Add support to specify VSCode extensions dir

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,21 +32,23 @@ program.command('get-chromedriver')
 program.command('install-vsix')
     .description('Install extension from vsix file into test instance of VSCode')
     .option('-s, --storage <storage>', 'Use this folder for all test resources')
+    .option('-e, --extensions_dir <extensions_directory>', 'VSCode will use this directory for managing extensions')
     .option('-f, --vsix_file <file>', 'vsix file containing the extension')
     .option('-y, --yarn', 'Use yarn to build the extension via vsce instead of npm', false)
     .action((cmd) => {
-        const extest = new ExTester(cmd.storage);
+        const extest = new ExTester(cmd.storage, cmd.extensions_dir);
         extest.installVsix({vsixFile: cmd.vsix_file, useYarn: cmd.yarn});
     });
 
 program.command('setup-tests')
     .description('Set up all necessary requirements for tests to run')
     .option('-s, --storage <storage>', 'Use this folder for all test resources')
+    .option('-e, --extensions_dir <extensions_directory>', 'VSCode will use this directory for managing extensions')
     .option('-c, --code_version <version>', 'Version of VSCode to download')
     .option('-t, --type <type>', 'Type of VSCode release (stable/insider)')
     .option('-y, --yarn', 'Use yarn to build the extension via vsce instead of npm', false)
     .action(async (cmd) => {
-        const extest = new ExTester(cmd.storage);
+        const extest = new ExTester(cmd.storage, cmd.extensions_dir);
         const version = loadCodeVersion(cmd.code_version);
         await extest.setupRequirements(version, cmd.type, cmd.yarn);
     });
@@ -54,13 +56,14 @@ program.command('setup-tests')
 program.command('run-tests <testFiles>')
     .description('Run the test files specified by a glob pattern')
     .option('-s, --storage <storage>', 'Use this folder for all test resources')
+    .option('-e, --extensions_dir <extensions_directory>', 'VSCode will use this directory for managing extensions')
     .option('-c, --code_version <version>', 'Version of VSCode to be used')
     .option('-t, --type <type>', 'Type of VSCode release (stable/insider)')
     .option('-o, --code_settings <settings.json>', 'Path to custom settings for VS Code json file')
     .option('-u, --uninstall_extension', 'Uninstall the extension after the test run', false)
     .option('-m, --mocha_config', 'Path to Mocha configuration file')
     .action(async (testFiles, cmd) => {
-        const extest = new ExTester(cmd.storage);
+        const extest = new ExTester(cmd.storage, cmd.extensions_dir);
         const version = loadCodeVersion(cmd.code_version);
         await extest.runTests(testFiles, version, cmd.type, cmd.code_settings, cmd.uninstall_extension, cmd.mocha_config);
     });
@@ -68,6 +71,7 @@ program.command('run-tests <testFiles>')
 program.command('setup-and-run <testFiles>')
     .description('Perform all setup and run tests specified by glob pattern')
     .option('-s, --storage <storage>', 'Use this folder for all test resources')
+    .option('-e, --extensions_dir <extensions_directory>', 'VSCode will use this directory for managing extensions')
     .option('-c, --code_version <version>', 'Version of VSCode to download')
     .option('-t, --type <type>', 'Type of VSCode release (stable/insider)')
     .option('-o, --code_settings <settings.json>', 'Path to custom settings for VS Code json file')
@@ -75,7 +79,7 @@ program.command('setup-and-run <testFiles>')
     .option('-u, --uninstall_extension', 'Uninstall the extension after the test run', false)
     .option('-m, --mocha_config <mocharc.js>', 'Path to Mocha configuration file')
     .action(async (testFiles, cmd) => {
-        const extest = new ExTester(cmd.storage);
+        const extest = new ExTester(cmd.storage, cmd.extensions_dir);
         const version = loadCodeVersion(cmd.code_version);
         await extest.setupAndRunTests(version, cmd.type, testFiles, cmd.code_settings, cmd.yarn, cmd.uninstall_extension, cmd.mocha_config);
     });

--- a/src/extester.ts
+++ b/src/extester.ts
@@ -63,8 +63,8 @@ export class ExTester {
     private code: CodeUtil;
     private chrome: DriverUtil;
 
-    constructor(storageFolder: string = 'test-resources') {
-        this.code = new CodeUtil(storageFolder);
+    constructor(storageFolder: string = 'test-resources', extensionsDir?: string) {
+        this.code = new CodeUtil(storageFolder, extensionsDir);
         this.chrome = new DriverUtil(storageFolder);
     }
 

--- a/src/webdriver/browser.ts
+++ b/src/webdriver/browser.ts
@@ -11,6 +11,7 @@ import compareVersions = require('compare-versions');
 
 export class VSBrowser {
     private storagePath: string;
+    private extensionsFolder: string | undefined;
     private customSettings: Object;
     private _driver!: WebDriver;
     private codeVersion: string;
@@ -19,6 +20,7 @@ export class VSBrowser {
 
     constructor(codeVersion: string, customSettings: Object = {}) {
         this.storagePath = process.env.TEST_RESOURCES ? process.env.TEST_RESOURCES : path.resolve('test-resources');
+        this.extensionsFolder = process.env.EXTENSIONS_FOLDER ? process.env.EXTENSIONS_FOLDER : undefined;
         this.customSettings = customSettings;
         this.codeVersion = codeVersion;
         VSBrowser._instance = this;
@@ -50,6 +52,11 @@ export class VSBrowser {
         console.log(`Writing code settings to ${path.join(userSettings, 'settings.json')}`);
         
         const args = ['--no-sandbox', `--user-data-dir=${path.join(this.storagePath, 'settings')}`];
+
+        if (this.extensionsFolder) {
+            args.push(`--extensions-dir=${this.extensionsFolder}`);
+        }
+
         if (compareVersions(this.codeVersion, '1.39.0') < 0) {
             if (process.platform === 'win32') {
                 fs.copyFileSync(path.resolve(__dirname, '..', '..', 'resources', 'state.vscdb'), path.join(userSettings, 'globalStorage', 'state.vscdb'));


### PR DESCRIPTION
This allows you to specify the path that will be used by VSCode to handle extensions.

Can be useful in order to launch your tests with an specific set of extensions. (e.g. copy the extensions that you want to use in your tests from your .vscode/extensions dir to a separate folder and use it in your tests).

Also can be used to prevent installed extensions to get in the way when running this project's tests (i got bitten by this issue).

Might be of help for this issue: https://github.com/redhat-developer/vscode-extension-tester/issues/33