### PR TITLE
Make findQuickPick return undefined when no QuickPick is found

### DIFF
--- a/page-objects/src/components/workbench/input/Input.ts
+++ b/page-objects/src/components/workbench/input/Input.ts
@@ -92,7 +92,7 @@ export abstract class Input extends AbstractElement {
      * @param indexOrText index (number) or text (string) of the item to search by
      * @returns Promise resolvnig to QuickPickItem if found, to undefined otherwise
      */
-    async findQuickPick(indexOrText: string | number): Promise<QuickPickItem | void> {
+    async findQuickPick(indexOrText: string | number): Promise<QuickPickItem | undefined> {
         const input = await this.findElement(Input.locators.Input.inputBox)
             .findElement(Input.locators.Input.input);
         const first = await this.findElements(Input.locators.Input.quickPickPosition(1));
@@ -123,6 +123,7 @@ export abstract class Input extends AbstractElement {
                 await input.sendKeys(Key.PAGE_DOWN);
             }
         }
+        return undefined;
     }
 
     /**


### PR DESCRIPTION
Currently `findQuickPick()` returns a `Promise<QuickPickItem|void>` which is inconvenient to use as you cannot use the return value directly without casting. For instance an assertion or the `?` operator only work on `null` or `undefined` but not on `void`.

This commit changes the return type to be consistent with the `Array.find()` function and returns now a `Promise<QuickPickItem|undefined>`, which removes the above inconveniences.