### PR TITLE
Use an octal integer when calling chmodSync

### DIFF
--- a/src/util/driverUtil.ts
+++ b/src/util/driverUtil.ts
@@ -61,7 +61,7 @@ export class DriverUtil {
         console.log(`Unpacking ChromeDriver ${version} into ${this.downloadFolder}`);
         await Unpack.unpack(fileName, this.downloadFolder);
         if (process.platform !== 'win32') {
-            fs.chmodSync(file, 755);
+            fs.chmodSync(file, 0o755);
         }
         console.log('Success!');
         return file;


### PR DESCRIPTION
`fs.chmodSync` passes integers directly to `chmod(2)` and interprets them as decimal integers, thus `fs.chmodSync(file, 755)` actually does the equivalent of:
``` ShellSession
$ chmod 1363 file
```
and **not**:
``` ShellSession
$ chmod 755 file
```
Thereby the chromedriver is downloaded and get's very weird file permissions on non-Windows: `--wxrw--wt`