### PR TITLE
Export the Editor class as well

### DIFF
--- a/page-objects/src/index.ts
+++ b/page-objects/src/index.ts
@@ -37,6 +37,7 @@ export * from './components/statusBar/StatusBar';
 
 export * from './components/editor/EditorView';
 export * from './components/editor/TextEditor';
+export * from './components/editor/Editor';
 export * from './components/editor/SettingsEditor';
 export * from './components/editor/DiffEditor';
 export * from './components/editor/WebView';


### PR DESCRIPTION
This allows us to directly use the type of the `openEditor` member function of the `EditorView` class.