### PR TITLE
Fix Build Status badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/redhat-developer/vscode-extension-tester.svg?branch=master)](https://travis-ci.com/redhat-developer/vscode-extension-tester)
+[![Build Status](https://travis-ci.org/redhat-developer/vscode-extension-tester.svg?branch=master)](https://travis-ci.org/redhat-developer/vscode-extension-tester)
 
 # Breaking news
 **3.0.0 contains an error that prevents it from being compiled without the native module. 3.0.1 fixes this, but native handlers are no longer part of the main API. You will need to import the native handling classes directly from vscode-extension-tester-native.**


### PR DESCRIPTION
The link was pointing to travis-ci.com, but the correct one is travis-ci.org