### PR TITLE
Use destructured parameters

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -7,6 +7,19 @@ import { WebDriver, Builder, until, By, initPageObjects, logging } from 'monaco-
 import { Options } from 'selenium-webdriver/chrome';
 import { getLocatorsPath } from 'vscode-extension-tester-locators';
 
+/** Logging levels supported by the WebDriver */
+export const enum VSBrowserLogLevel {
+  All,
+  Finest,
+  Finer,
+  Fine,
+  Debug,
+  Info,
+  Warning,
+  Severe,
+  Off,
+}
+
 export class VSBrowser {
     static readonly baseVersion = '1.37.0';
     static readonly browserName = 'vscode';
@@ -23,17 +36,18 @@ export class VSBrowser {
     private logLevel: logging.Level;
     private static _instance: VSBrowser;
 
-    constructor(codeVersion: string, customSettings: Object = {}, logLevel: string = 'info') {
+    private static logLevelToLoggingLevel(logLevel: VSBrowserLogLevel): logging.Level {
+        const level = VSBrowser.logLevels[logLevel.toString()];
+        return level ?? logging.Level.INFO;
+    }
+
+    constructor(codeVersion: string, customSettings: Object = {}, logLevel: VSBrowserLogLevel = VSBrowserLogLevel.Info) {
         this.storagePath = process.env.TEST_RESOURCES ? process.env.TEST_RESOURCES : path.resolve('test-resources');
         this.extensionsFolder = process.env.EXTENSIONS_FOLDER ? process.env.EXTENSIONS_FOLDER : undefined;
         this.customSettings = customSettings;
         this.codeVersion = codeVersion;
 
-        if (VSBrowser.logLevels[logLevel.toLowerCase()]) {
-            this.logLevel = VSBrowser.logLevels[logLevel.toLowerCase()];
-        } else {
-            this.logLevel = logging.Level.INFO;
-        }
+        this.logLevel = VSBrowser.logLevelToLoggingLevel(logLevel);
 
         VSBrowser._instance = this;
     };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -67,8 +67,8 @@ program.command('setup-tests')
     .option('-i, --install_dependencies', 'Automatically install extensions your extension depends on', false)
     .action(withErrors(async (cmd) => {
         const extest = new ExTester(cmd.storage, codeStream(cmd.type), cmd.extensions_dir);
-        const version = loadCodeVersion(cmd.code_version);
-        await extest.setupRequirements(version, cmd.yarn, cmd.install_dependencies);
+        const vscodeVersion = loadCodeVersion(cmd.code_version);
+        await extest.setupRequirements({vscodeVersion, useYarn: cmd.yarn, installDependencies: cmd.install_dependencies});
     }));
 
 program.command('run-tests <testFiles>')
@@ -80,11 +80,11 @@ program.command('run-tests <testFiles>')
     .option('-o, --code_settings <settings.json>', 'Path to custom settings for VS Code json file')
     .option('-u, --uninstall_extension', 'Uninstall the extension after the test run', false)
     .option('-m, --mocha_config', 'Path to Mocha configuration file')
-    .option('-l, --log_level <level>', 'Log messages from webdriver with a given level', 'info')
+    .option('-l, --log_level <level>', 'Log messages from webdriver with a given level', 'Info')
     .action(withErrors(async (testFiles, cmd) => {
         const extest = new ExTester(cmd.storage, codeStream(cmd.type), cmd.extensions_dir);
-        const version = loadCodeVersion(cmd.code_version);
-        await extest.runTests(testFiles, version, cmd.code_settings, cmd.uninstall_extension, cmd.mocha_config, cmd.log_level);
+        const vscodeVersion = loadCodeVersion(cmd.code_version);
+        await extest.runTests(testFiles, {vscodeVersion, settings: cmd.code_settings, cleanup: cmd.uninstall_extension, config: cmd.mocha_config, logLevel: cmd.log_level});
     }));
 
 program.command('setup-and-run <testFiles>')
@@ -98,11 +98,11 @@ program.command('setup-and-run <testFiles>')
     .option('-u, --uninstall_extension', 'Uninstall the extension after the test run', false)
     .option('-m, --mocha_config <mocharc.js>', 'Path to Mocha configuration file')
     .option('-i, --install_dependencies', 'Automatically install extensions your extension depends on', false)
-    .option('-l, --log_level <level>', 'Log messages from webdriver with a given level', 'info')
+    .option('-l, --log_level <level>', 'Log messages from webdriver with a given level', 'Info')
     .action(withErrors(async (testFiles, cmd) => {
         const extest = new ExTester(cmd.storage, codeStream(cmd.type), cmd.extensions_dir);
-        const version = loadCodeVersion(cmd.code_version);
-        await extest.setupAndRunTests(version, testFiles, cmd.code_settings, cmd.yarn, cmd.uninstall_extension, cmd.mocha_config, cmd.install_dependencies, cmd.log_level);
+        const vscodeVersion = loadCodeVersion(cmd.code_version);
+        await extest.setupAndRunTests(testFiles, vscodeVersion, {useYarn: cmd.yarn, installDependencies: cmd.install_dependencies}, {settings: cmd.code_settings, cleanup: cmd.uninstall_extension, config: cmd.mocha_config, logLevel: cmd.log_level});
     }));
 
 program.parse(process.argv);

--- a/src/suite/runner.ts
+++ b/src/suite/runner.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { VSBrowser } from '../browser';
+import { VSBrowser, VSBrowserLogLevel } from '../browser';
 import * as fs from 'fs-extra';
 import Mocha = require('mocha');
 import * as glob from 'glob';
@@ -30,8 +30,9 @@ export class VSRunner {
     /**
      * Set up mocha suite, add vscode instance handling, run tests
      * @param testFilesPattern glob pattern of test files to run
+     * @return The exit code of the mocha process
      */
-    runTests(testFilesPattern: string, code: CodeUtil, logLevel: string = 'info'): Promise<number> {
+    runTests(testFilesPattern: string, code: CodeUtil, logLevel: VSBrowserLogLevel = VSBrowserLogLevel.Info): Promise<number> {
         return new Promise(resolve => {
             let self = this;
             let browser: VSBrowser = new VSBrowser(this.codeVersion, this.customSettings, logLevel);


### PR DESCRIPTION
Currently extester has a plethora of options, of which not all have to be set by
the user. This makes it awkward if one wants to use the default for most
options, but only modify the last one. To remedy this, we switch to objects for
all the optional arguments, which makes the API more convenient to use in this
case.

Note: this will probably warrant a major version bump.