### PR TITLE
Correct apiUrl for downloading VSCode

### DIFF
--- a/src/util/codeUtil.ts
+++ b/src/util/codeUtil.ts
@@ -53,7 +53,7 @@ export class CodeUtil {
      * Get all versions for the given release stream
      */
     async getVSCodeVersions(): Promise<string[]> {
-        const apiUrl = `https://vscode-update.azurewebsites.net/api/releases/${this.releaseType}`;
+        const apiUrl = `https://update.code.visualstudio.com/api/releases/${this.releaseType}`;
         const headers = {
             'user-agent': 'nodejs'
         };


### PR DESCRIPTION
The old url now redirects to https://update.code.visualstudio.com/api/releases/ which the download code does not follow, thereby unfortunately breaking vscode-extension-tester.