### PR TITLE
Add API to access welcome content

### DIFF
--- a/locators/lib/1.37.0.ts
+++ b/locators/lib/1.37.0.ts
@@ -177,7 +177,8 @@ const sideBar = {
         button: By.xpath(`.//a[@role='button']`),
         buttonLabel: 'title',
         level: 'aria-level',
-        index: 'data-index'
+        index: 'data-index',
+        welcomeContent: By.xpath('.//div[@class="pane-body welcome"]')
     },
     TreeItem: {
         actions: By.className('actions-container'),
@@ -329,6 +330,17 @@ const dialog = {
     }
 }
 
+const welcomeContentButtonSelector = ".//a[@class='monaco-button monaco-text-button']"
+const welcomeContentTextSelector = ".//p"
+
+const welcome = {
+    WelcomeContent: {
+        button: By.xpath(welcomeContentButtonSelector),
+        buttonOrText: By.xpath(`${welcomeContentButtonSelector} | ${welcomeContentTextSelector}`),
+        text: By.xpath(welcomeContentTextSelector)
+    }
+}
+
 /**
  * All available locators for vscode version 1.37.0
  */
@@ -341,5 +353,6 @@ export const locators: Locators = {
     ...statusBar,
     ...workbench,
     ...input,
-    ...dialog
+    ...dialog,
+    ...welcome
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,14 @@
         }
       }
     },
+    "@types/sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-1dAV8Va7KsiXNAstV2JmF4CRVG3Fsyl+VnBw87C9cCMccekpOqJBezS7MUnHYPChNAFee1WakwBXdfn7QJxzVg==",
+      "requires": {
+        "sanitize-filename": "*"
+      }
+    },
     "@types/selenium-webdriver": {
       "version": "3.0.17",
       "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-3.0.17.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "homepage": "https://github.com/redhat-developer/vscode-extension-tester#readme",
   "devDependencies": {
+    "@types/sanitize-filename": "^1.6.3",
     "@types/fs-extra": "^9.0.1",
     "@types/glob": "^7.1.1",
     "@types/js-yaml": "^3.12.1",

--- a/page-objects/src/components/sidebar/ViewSection.ts
+++ b/page-objects/src/components/sidebar/ViewSection.ts
@@ -1,6 +1,7 @@
-import { AbstractElement } from "../AbstractElement";
-import { ViewContent, ViewItem, waitForAttributeValue } from "../..";
 import { until, WebElement } from "selenium-webdriver";
+import { ViewContent, ViewItem, waitForAttributeValue } from "../..";
+import { AbstractElement } from "../AbstractElement";
+import { WelcomeContentSection } from "./WelcomeContent";
 
 /**
  * Page object representing a collapsible content section of the side bar view
@@ -58,6 +59,20 @@ export abstract class ViewSection extends AbstractElement {
         const header = await this.findElement(ViewSection.locators.ViewSection.header);
         const expanded = await header.getAttribute(ViewSection.locators.ViewSection.headerExpanded);
         return expanded === 'true';
+    }
+
+    /**
+     * Finds [Welcome Content](https://code.visualstudio.com/api/extension-guides/tree-view#welcome-content)
+     * present in this ViewSection and returns it. If none is found, then `undefined` is returned
+     *
+     */
+    public async findWelcomeContent(): Promise<WelcomeContentSection | undefined> {
+        try {
+            const res = await this.findElement(ViewSection.locators.ViewSection.welcomeContent);
+            return new WelcomeContentSection(res, this);
+        } catch (_err) {
+            return undefined;
+        }
     }
 
     /**

--- a/page-objects/src/components/sidebar/WelcomeContent.ts
+++ b/page-objects/src/components/sidebar/WelcomeContent.ts
@@ -1,0 +1,77 @@
+import { WebElement } from "selenium-webdriver";
+import { AbstractElement } from "../AbstractElement";
+import { ViewSection } from "./ViewSection";
+
+/**
+ * A button that appears in the welcome content and can be clicked to execute a command.
+ *
+ * To execute the command bound to this button simply run: `await button.click();`.
+ */
+export class WelcomeContentButton extends AbstractElement {
+    /**
+     * @param panel  The panel containing the button in the welcome section
+     * @param welcomeSection  The enclosing welcome section
+     */
+    constructor(panel: WebElement, welcomeSection: WelcomeContentSection) {
+        super(panel, welcomeSection);
+    }
+
+    /** Return the title displayed on this button */
+    public async getTitle(): Promise<string> {
+        return this.getText();
+    }
+}
+
+/**
+ * A section in an empty custom view, see:
+ * https://code.visualstudio.com/api/extension-guides/tree-view#welcome-content
+ *
+ * The welcome section contains two types of elements: text entries and buttons that can be bound to commands.
+ * The text sections can be accessed via [[getTextSections]], the buttons on the
+ * other hand via [[getButtons]].
+ * This however looses the information of the order of the buttons and lines
+ * with respect to each other. This can be remedied by using [[getContents]],
+ * which returns both in the order that they are found (at the expense, that you
+ * now must use typechecks to find out what you got).
+ */
+export class WelcomeContentSection extends AbstractElement {
+    /**
+     * @param panel  The panel containing the welcome content.
+     * @param parent  The webelement in which the welcome content is embedded.
+     */
+    constructor(panel: WebElement, parent: ViewSection) {
+        super(panel, parent);
+    }
+
+    /**
+     * Combination of [[getButtons]] and [[getTextSections]]: returns all entries in the welcome view in the order that they appear.
+     */
+    public async getContents(): Promise<(WelcomeContentButton|string)[]> {
+        const elements = await this.findElements(WelcomeContentSection.locators.WelcomeContent.buttonOrText);
+        return Promise.all(elements.map(async (e) => {
+            const tagName = await e.getTagName();
+            if (tagName === "p") {
+                return e.getText();
+            } else {
+                return new WelcomeContentButton(e, this);
+            }
+        }));
+    }
+
+    /** Finds all buttons in the welcome content */
+    public async getButtons(): Promise<WelcomeContentButton[]> {
+        return (
+            await this.findElements(WelcomeContentSection.locators.WelcomeContent.button)
+        ).map((elem) => new WelcomeContentButton(elem, this));
+    }
+
+    /**
+     * Finds all text entries in the welcome content and returns each line as an
+     * element in an array.
+     */
+    public async getTextSections(): Promise<string[]> {
+        return Promise.all(
+            (await this.findElements(WelcomeContentSection.locators.WelcomeContent.text)).map((elem) => elem.getText())
+        );
+    }
+}

--- a/page-objects/src/index.ts
+++ b/page-objects/src/index.ts
@@ -20,6 +20,7 @@ export * from './components/sidebar/ViewTitlePart';
 export * from './components/sidebar/ViewContent';
 export * from './components/sidebar/ViewSection';
 export * from './components/sidebar/ViewItem';
+export * from './components/sidebar/WelcomeContent';
 
 export * from './components/sidebar/tree/default/DefaultTreeSection';
 export * from './components/sidebar/tree/default/DefaultTreeItem';

--- a/page-objects/src/locators/locators.ts
+++ b/page-objects/src/locators/locators.ts
@@ -178,6 +178,7 @@ export interface Locators {
         buttonLabel: string
         level: string
         index: string
+        welcomeContent: By
     }
     TreeItem: {
         actions: By
@@ -322,6 +323,12 @@ export interface Locators {
         buttonContainer: By
         button: By
         closeButton: By
+    }
+
+    WelcomeContent: {
+        button: By,
+        text: By,
+        buttonOrText: By
     }
 }
 

--- a/test/test-project/package.json
+++ b/test/test-project/package.json
@@ -66,6 +66,10 @@
 			{
 				"command": "extension.quickpick",
 				"title": "Test Quickpicks"
+			},
+			{
+				"command": "extension.populateTestView",
+				"title": "Populate Test View"
 			}
 		],
 		"views": {
@@ -73,9 +77,19 @@
 				{
 					"id": "testView",
 					"name": "Test View"
+				},
+				{
+					"id": "emptyView",
+					"name": "Empty View"
 				}
 			]
 		},
+	        "viewsWelcome": [
+			{
+				"view": "emptyView",
+				"contents": "This is the first line\n[Add stuff into this View](command:extension.populateTestView)\nThis is the second line\nAnd yet another line."
+				}
+		],
 		"configuration": {
 			"title": "Test Project",
 			"properties": {

--- a/test/test-project/src/extension.ts
+++ b/test/test-project/src/extension.ts
@@ -44,9 +44,23 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand('extension.errorMsg', () => vscode.window.showErrorMessage("This is an error!")));
 
 	new TreeView(context);
+
+	context.subscriptions.push(vscode.window.createTreeView("emptyView", { treeDataProvider: {
+		getChildren: () => emptyViewNoContent ? undefined : [{key: "There is content!"}],
+		getTreeItem: (e) => new vscode.TreeItem(e.key),
+		onDidChangeTreeData: emitter.event,
+	}}))
+
+	context.subscriptions.push(vscode.commands.registerCommand(
+		"extension.populateTestView",
+		() => { emptyViewNoContent = false; emitter.fire(undefined); }
+	));
 }
 
 export function deactivate() {}
+
+let emptyViewNoContent: boolean = true;
+const emitter = new vscode.EventEmitter<{key: string}>();
 
 class TestView {
 	private static instance: TestView | undefined;


### PR DESCRIPTION
This is a very crude and far from finished PR to add support for [Welcome Content](https://code.visualstudio.com/api/extension-guides/tree-view#welcome-content) in tree views.

To make things a bit complicated, every tree view section has a `welcome-view` and `welcome-view-content` sub element, but they are invisible/without content. When they are actually visible, then the content is present in the div with the class name `pane-body welcome`.

The part that is currently missing is which content to get out of the welcome view. Welcome views have afaik only text and buttons which can be clicked. The content is present as child element of the div with class name `welcome-view-content`. Text content is simply present in `<p>` elements, the buttons on the other hand use the `a` element with the class `monaco-button monaco-text-button`.

I would propose to create a class `WelcomeContent` that is returned by `getWelcomeContent()` and that has the function `getContent()` which would return a Promise returning an Array of either text (extracted from `<p></p>`) or actionable buttons (these could be similar to the way notification buttons behave).