### PR TITLE
Fix Notification.getType() not finding error notifications properly

### DIFF
--- a/page-objects/src/components/workbench/Notification.ts
+++ b/page-objects/src/components/workbench/Notification.ts
@@ -33,7 +33,7 @@ export abstract class Notification extends ElementWithContexMenu {
         const iconType = await this.findElement(Notification.locators.Notification.icon).getAttribute('class');
         if (iconType.indexOf('icon-info') > -1) {
             return NotificationType.Info;
-        } else if (iconType.indexOf('icon-warning')) {
+        } else if (iconType.indexOf('icon-warning') > -1) {
             return NotificationType.Warning;
         } else {
             return NotificationType.Error;

--- a/test/test-project/package.json
+++ b/test/test-project/package.json
@@ -32,6 +32,14 @@
 				"title": "Hello World"
 			},
 			{
+				"command": "extension.warningMsg",
+				"title": "Warning Message"
+                        },
+                        {
+				"command": "extension.errorMsg",
+				"title": "Error Message"
+			},
+			{
 				"command": "extension.openFile",
 				"title": "Open Test File"
 			},

--- a/test/test-project/src/extension.ts
+++ b/test/test-project/src/extension.ts
@@ -40,6 +40,8 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(webViewCommand);
 	context.subscriptions.push(notificationCommand);
 	context.subscriptions.push(quickPickCommand);
+	context.subscriptions.push(vscode.commands.registerCommand('extension.warningMsg', () => vscode.window.showWarningMessage("This is a warning!")));
+	context.subscriptions.push(vscode.commands.registerCommand('extension.errorMsg', () => vscode.window.showErrorMessage("This is an error!")));
 
 	new TreeView(context);
 }

--- a/test/test-project/src/test/workbench/notifications-test.ts
+++ b/test/test-project/src/test/workbench/notifications-test.ts
@@ -51,7 +51,7 @@ describe('NotificationsCenter', () => {
             expect(message).has.string('This is a notification');
         });
 
-        it('getType returns notificationYype', async () => {
+        it('getType returns notificationType', async () => {
             const type = await notification.getType();
             expect(type).equals(NotificationType.Info);
         });

--- a/test/test-project/src/test/workbench/notifications-test.ts
+++ b/test/test-project/src/test/workbench/notifications-test.ts
@@ -88,5 +88,29 @@ describe('NotificationsCenter', () => {
             await notification.dismiss();
             await driver.wait(until.stalenessOf(notification));
         });
+
+        it('get warning notification works', async () => {
+            await new Workbench().executeCommand('Warning Message');
+            await center.getDriver().sleep(200);
+            center = await new Workbench().openNotificationsCenter();
+            notification = (await center.getNotifications(NotificationType.Warning))[0];
+
+            expect(await notification.getMessage()).to.equal("This is a warning!");
+            expect(await notification.getType()).to.equal(NotificationType.Warning);
+            await notification.dismiss();
+            await center.getDriver().wait(until.stalenessOf(notification));
+        })
+
+        it('get error notification works', async () => {
+            await new Workbench().executeCommand('Error Message');
+            await center.getDriver().sleep(200);
+            center = await new Workbench().openNotificationsCenter();
+            notification = (await center.getNotifications(NotificationType.Error))[0];
+
+            expect(await notification.getMessage()).to.equal("This is an error!");
+            expect(await notification.getType()).to.equal(NotificationType.Error);
+            await notification.dismiss();
+            await center.getDriver().wait(until.stalenessOf(notification));
+        })
     });
 });

--- a/test/test-project/src/treeView.ts
+++ b/test/test-project/src/treeView.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 export class TreeView {
     constructor(context: vscode.ExtensionContext) {
         const view = vscode.window.createTreeView('testView', { treeDataProvider: dataProvider(), showCollapseAll: true });
+        context.subscriptions.push(view);
     }
 }
 


### PR DESCRIPTION
`indexOf()` returns a number which only evaluates to false if the result is 0, which is not correct, as the condition should evaluate to false when it is -1