### PR TITLE
Make TextEditor.getCoordinates() public 

### DIFF
--- a/page-objects/src/components/editor/TextEditor.ts
+++ b/page-objects/src/components/editor/TextEditor.ts
@@ -220,15 +220,17 @@ export class TextEditor extends Editor {
     }
 
     /**
-     * Get coordinates as number array [line, column]
+     * Get the cursor's coordinates as an array of two numbers: `[line, column]`
+     *
+     * **Caution** line & column coordinates do not start at `0` but at `1`!
      */
-    private async getCoordinates(): Promise<number[]> {
+    public async getCoordinates(): Promise<[number, number]> {
         const coords: number[] = [];
         const statusBar = new StatusBar();
         const coordinates = <RegExpMatchArray>(await statusBar.getCurrentPosition()).match(/\d+/g);
         for(const c of coordinates) {
             coords.push(+c);
         }
-        return coords;
+        return [coords[0], coords[1]];
     }
 }

--- a/test/test-project/src/test/activityBar/viewControl-test.ts
+++ b/test/test-project/src/test/activityBar/viewControl-test.ts
@@ -30,7 +30,7 @@ describe('ViewControl', () => {
     });
 
     it('getTitle returns container label', async () => {
-        const title = await control.getTitle();
+        const title = control.getTitle();
         expect(title).equals('Explorer');
     });
 

--- a/test/test-project/src/test/editor/textEditor-test.ts
+++ b/test/test-project/src/test/editor/textEditor-test.ts
@@ -79,6 +79,18 @@ describe('TextEditor', () => {
         expect(line).has.string('line11');
     });
 
+    it('getCoordinates works', async () => {
+        await editor.moveCursor(1, 1);
+        expect(await editor.getCoordinates()).to.deep.equal([1, 1]);
+
+        const lineCount = await editor.getNumberOfLines();
+        const lastLine = await editor.getTextAtLine(lineCount);
+
+        await editor.moveCursor(lineCount, lastLine.length);
+
+        expect(await editor.getCoordinates()).to.deep.equal([lineCount, lastLine.length]);
+    })
+
     it('getNumberOfLines works', async () => {
         const lines = await editor.getNumberOfLines();
         expect(lines).equals(3);


### PR DESCRIPTION
This function is rather convenient to be able to test that a command put us at the correct position.