### PR TITLE
hasChildren broken for items without children but that are expandable

### DIFF
--- a/test/test-project/src/test/xsideBar/customView-test.ts
+++ b/test/test-project/src/test/xsideBar/customView-test.ts
@@ -36,7 +36,7 @@ describe('CustomTreeSection', () => {
 
     it('getVisibleItems works', async () => {
         const items = await section.getVisibleItems();
-        expect(items.length).equals(2);
+        expect(items.length).equals(3);
     });
 
     it('findItem works', async () => {
@@ -44,7 +44,7 @@ describe('CustomTreeSection', () => {
         expect(item).not.undefined;
 
 
-        const item1 = await section.findItem('c');
+        const item1 = await section.findItem('d');
         expect(item1).undefined;
     });
 
@@ -141,6 +141,11 @@ describe('CustomTreeSection', () => {
         it('hasChildren works', async () => {
             const children = await item.hasChildren();
             expect(children).is.true;
+        });
+
+        it('hasChildren works for expandable elements without children', async () => {
+            const cItem = await section.findItem('c');
+            expect(await cItem.hasChildren()).is.false;
         });
 
         it('getChildren works', async () => {

--- a/test/test-project/src/treeView.ts
+++ b/test/test-project/src/treeView.ts
@@ -11,32 +11,35 @@ export class TreeView {
     }
 }
 
-const tree = {
+type Tree = { [key: string]: Tree | undefined | null };
+
+// structure of the test tree:
+// leafs are keys that are undefined or null. If it is undefined, then its collapsibleState is None, if it null, then it is Collapsed
+const tree: Tree = {
 	'a': {
 		'aa': {
 			'aaa': {
 				'aaaa': {
 					'aaaaa': {
-						'aaaaaa': {
-
-						}
+						'aaaaaa': undefined,
 					}
 				}
 			}
 		},
-		'ab': {}
+		'ab': undefined,
 	},
 	'b': {
-		'ba': {},
-		'bb': {}
-	}
+		'ba': undefined,
+		'bb': undefined
+	},
+	'c': null
 };
 let nodes = {};
 
 function dataProvider(): vscode.TreeDataProvider<{ key: string }> {
     return {
-		getChildren: (element: { key: string }): { key: string }[] => {
-			return getChildren(element ? element.key : undefined).map((key: string) => getNode(key));
+		getChildren: (element?: { key: string }): { key: string }[] => {
+			return getChildren(element?.key).map((key: string) => getNode(key));
 		},
 		getTreeItem: (element: { key: string }): vscode.TreeItem => {
 			const treeItem = getTreeItem(element.key);
@@ -63,19 +66,25 @@ function getChildren(key: string | undefined): string[] {
 
 function getTreeItem(key: string): vscode.TreeItem {
 	const treeElement = getTreeElement(key);
+	let collapsibleState: vscode.TreeItemCollapsibleState;
+	  if (treeElement === undefined) {
+        collapsibleState = vscode.TreeItemCollapsibleState.None;
+    } else {
+        collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+    }
 	return {
 		label: key,
 		tooltip: `Tooltip for ${key}`,
-		collapsibleState: treeElement && Object.keys(treeElement).length ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None
+		collapsibleState
 	};
 }
 
-function getTreeElement(element): any {
+function getTreeElement(element: string): null | undefined | Tree {
 	let parent = tree;
 	for (let i = 0; i < element.length; i++) {
 		parent = parent[element.substring(0, i + 1)];
-		if (!parent) {
-			return null;
+		if (parent === null || parent === undefined) {
+			return parent;
 		}
 	}
 	return parent;


### PR DESCRIPTION
There is a small bug in `CustomTreeItem.hasChildren()`: it only checks whether the current tree item can be expanded or not, but that is actually not sufficient. You can have a tree item that has no children, but which has a `collapsibleState` that is not `None`.

Unfortunately, I don't have a good solution for this. I have tried to return `(await this.getChildren()).length > 0` from `hasChildren()`, but that results in a whole ton of `StaleElementReferenceError` exceptions. So this PR currently only adds a failing reproducer test.