### PR TITLE
Change TreeItem children checks

### DIFF
--- a/page-objects/src/components/sidebar/ViewItem.ts
+++ b/page-objects/src/components/sidebar/ViewItem.ts
@@ -37,22 +37,32 @@ export abstract class TreeItem extends ViewItem {
     }
 
     /**
-     * Finds whether the item has children (whether it is collapsible)
+     * Finds if the item has children by actually counting the child items
+     * Note that this will expand the item if it was collapsed
      * @returns Promise resolving to true/false
      */
-    abstract async hasChildren(): Promise<boolean>
+    async hasChildren(): Promise<boolean> {
+        const children = await this.getChildren();
+        return children && children.length > 0;
+    }
 
     /**
      * Finds whether the item is expanded. Always returns false if item has no children.
      * @returns Promise resolving to true/false
      */
-    abstract async isExpanded(): Promise<boolean>
+    abstract isExpanded(): Promise<boolean>
 
     /**
      * Find children of an item, will try to expand the item in the process
      * @returns Promise resolving to array of TreeItem objects, empty array if item has no children
      */
-    abstract async getChildren(): Promise<TreeItem[]>
+    abstract getChildren(): Promise<TreeItem[]>
+
+    /**
+     * Finds if the item is expandable/collapsible 
+     * @returns Promise resolving to true/false
+     */
+    abstract isExpandable(): Promise<boolean>;
 
     /**
      * Find a child item with the given name
@@ -71,7 +81,7 @@ export abstract class TreeItem extends ViewItem {
      * Collapse the item if expanded
      */
     async collapse(): Promise<void> {
-        if (await this.hasChildren() && await this.isExpanded()) {
+        if (await this.isExpandable() && await this.isExpanded()) {
             await this.click();
         }
     }
@@ -120,7 +130,7 @@ export abstract class TreeItem extends ViewItem {
      */
     protected async getChildItems(locator: By): Promise<WebElement[]> {
         const items: WebElement[] = [];
-        if (!await this.isExpanded() && this.hasChildren()) {
+        if (!await this.isExpanded() && this.isExpandable()) {
             await this.click();
         }
         const rows = await this.enclosingItem.findElements(locator);

--- a/page-objects/src/components/sidebar/tree/custom/CustomTreeItem.ts
+++ b/page-objects/src/components/sidebar/tree/custom/CustomTreeItem.ts
@@ -18,11 +18,6 @@ export class CustomTreeItem extends TreeItem {
         return this.getAttribute(CustomTreeItem.locators.CustomTreeItem.tooltipAttribute);
     }
 
-    async hasChildren(): Promise<boolean> {
-        const attr = await this.getAttribute(CustomTreeItem.locators.CustomTreeItem.expandedAttr);
-        return attr !== null;
-    }
-
     async isExpanded(): Promise<boolean> {
         const attr = await this.getAttribute(CustomTreeItem.locators.CustomTreeItem.expandedAttr);
         return attr === CustomTreeItem.locators.CustomTreeItem.expandedValue;
@@ -32,5 +27,10 @@ export class CustomTreeItem extends TreeItem {
         const rows = await this.getChildItems(CustomTreeItem.locators.DefaultTreeSection.itemRow);
         const items = await Promise.all(rows.map(async row => new CustomTreeItem(row, this.enclosingItem as TreeSection).wait()));
         return items;
+    }
+
+    async isExpandable(): Promise<boolean> {
+        const attr = await this.getAttribute(CustomTreeItem.locators.CustomTreeItem.expandedAttr);
+        return attr !== null;
     }
 }

--- a/page-objects/src/components/sidebar/tree/default/DefaultTreeItem.ts
+++ b/page-objects/src/components/sidebar/tree/default/DefaultTreeItem.ts
@@ -19,11 +19,6 @@ export class DefaultTreeItem extends TreeItem {
         return tooltip.getAttribute('title');
     }
 
-    async hasChildren(): Promise<boolean> {
-        const twistieClass = await this.findElement(DefaultTreeItem.locators.DefaultTreeItem.twistie).getAttribute('class');
-        return twistieClass.indexOf('collapsible') > -1;
-    }
-
     async isExpanded(): Promise<boolean> {
         const twistieClass = await this.findElement(DefaultTreeItem.locators.DefaultTreeItem.twistie).getAttribute('class');
         return twistieClass.indexOf('collapsed') < 0;
@@ -33,5 +28,10 @@ export class DefaultTreeItem extends TreeItem {
         const rows = await this.getChildItems(DefaultTreeItem.locators.DefaultTreeSection.itemRow);
         const items = await Promise.all(rows.map(async row => new DefaultTreeItem(row, this.enclosingItem as TreeSection).wait()));
         return items;
+    }
+
+    async isExpandable(): Promise<boolean> {
+        const twistieClass = await this.findElement(DefaultTreeItem.locators.DefaultTreeItem.twistie).getAttribute('class');
+        return twistieClass.indexOf('collapsible') > -1;
     }
 }

--- a/test/test-project/src/test/xsideBar/customView-test.ts
+++ b/test/test-project/src/test/xsideBar/customView-test.ts
@@ -36,7 +36,7 @@ describe('CustomTreeSection', () => {
 
     it('getVisibleItems works', async () => {
         const items = await section.getVisibleItems();
-        expect(items.length).equals(2);
+        expect(items.length).equals(3);
     });
 
     it('findItem works', async () => {
@@ -44,7 +44,7 @@ describe('CustomTreeSection', () => {
         expect(item).not.undefined;
 
 
-        const item1 = await section.findItem('c');
+        const item1 = await section.findItem('d');
         expect(item1).undefined;
     });
 
@@ -141,6 +141,11 @@ describe('CustomTreeSection', () => {
         it('hasChildren works', async () => {
             const children = await item.hasChildren();
             expect(children).is.true;
+        });
+
+        it('hasChildren works for expandable elements without children', async () => {
+            const cItem = await section.findItem('c');
+            expect(await cItem.hasChildren()).is.false;
         });
 
         it('getChildren works', async () => {

--- a/test/test-project/src/test/xsideBar/customView-test.ts
+++ b/test/test-project/src/test/xsideBar/customView-test.ts
@@ -113,6 +113,7 @@ describe('CustomTreeSection', () => {
         let item: CustomTreeItem;
 
         before(async () => {
+            await emptyViewSection.collapse();
             item = await section.findItem('a') as CustomTreeItem;
         });
 

--- a/test/test-project/src/treeView.ts
+++ b/test/test-project/src/treeView.ts
@@ -11,32 +11,35 @@ export class TreeView {
     }
 }
 
-const tree = {
+type Tree = { [key: string]: Tree | undefined | null };
+
+// structure of the test tree:
+// leafs are keys that are undefined or null. If it is undefined, then its collapsibleState is None, if it null, then it is Collapsed
+const tree: Tree = {
 	'a': {
 		'aa': {
 			'aaa': {
 				'aaaa': {
 					'aaaaa': {
-						'aaaaaa': {
-
-						}
+						'aaaaaa': undefined,
 					}
 				}
 			}
 		},
-		'ab': {}
+		'ab': undefined,
 	},
 	'b': {
-		'ba': {},
-		'bb': {}
-	}
+		'ba': undefined,
+		'bb': undefined
+	},
+	'c': null
 };
 let nodes = {};
 
 function dataProvider(): vscode.TreeDataProvider<{ key: string }> {
     return {
-		getChildren: (element: { key: string }): { key: string }[] => {
-			return getChildren(element ? element.key : undefined).map((key: string) => getNode(key));
+		getChildren: (element?: { key: string }): { key: string }[] => {
+			return getChildren(element?.key).map((key: string) => getNode(key));
 		},
 		getTreeItem: (element: { key: string }): vscode.TreeItem => {
 			const treeItem = getTreeItem(element.key);
@@ -63,19 +66,25 @@ function getChildren(key: string | undefined): string[] {
 
 function getTreeItem(key: string): vscode.TreeItem {
 	const treeElement = getTreeElement(key);
+	let collapsibleState: vscode.TreeItemCollapsibleState;
+	  if (treeElement === undefined) {
+        collapsibleState = vscode.TreeItemCollapsibleState.None;
+    } else {
+        collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+    }
 	return {
 		label: key,
 		tooltip: `Tooltip for ${key}`,
-		collapsibleState: treeElement && Object.keys(treeElement).length ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None
+		collapsibleState
 	};
 }
 
-function getTreeElement(element): any {
+function getTreeElement(element: string): null | undefined | Tree {
 	let parent = tree;
 	for (let i = 0; i < element.length; i++) {
 		parent = parent[element.substring(0, i + 1)];
-		if (!parent) {
-			return null;
+		if (parent === null || parent === undefined) {
+			return parent;
 		}
 	}
 	return parent;


### PR DESCRIPTION
- move `hasChildren` functionality to `isExpandable`
- rework `hasChildren` to actually count the child items