### PR TITLE
Fix broken loglevel conversion

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -7,27 +7,9 @@ import { WebDriver, Builder, until, By, initPageObjects, logging } from 'monaco-
 import { Options } from 'selenium-webdriver/chrome';
 import { getLocatorsPath } from 'vscode-extension-tester-locators';
 
-/** Logging levels supported by the WebDriver */
-export const enum VSBrowserLogLevel {
-  All,
-  Finest,
-  Finer,
-  Fine,
-  Debug,
-  Info,
-  Warning,
-  Severe,
-  Off,
-}
-
 export class VSBrowser {
     static readonly baseVersion = '1.37.0';
     static readonly browserName = 'vscode';
-    static readonly logLevels: { [key: string]: logging.Level } = {
-        'all': logging.Level.ALL, 'finest': logging.Level.FINEST, 'finer': logging.Level.FINER,
-        'fine': logging.Level.FINE, 'debug': logging.Level.DEBUG, 'info': logging.Level.INFO,
-        'warning': logging.Level.WARNING, 'severe': logging.Level.SEVERE, 'off': logging.Level.OFF
-    };
     private storagePath: string;
     private extensionsFolder: string | undefined;
     private customSettings: Object;
@@ -36,18 +18,13 @@ export class VSBrowser {
     private logLevel: logging.Level;
     private static _instance: VSBrowser;
 
-    private static logLevelToLoggingLevel(logLevel: VSBrowserLogLevel): logging.Level {
-        const level = VSBrowser.logLevels[logLevel.toString()];
-        return level ?? logging.Level.INFO;
-    }
-
-    constructor(codeVersion: string, customSettings: Object = {}, logLevel: VSBrowserLogLevel = VSBrowserLogLevel.Info) {
+    constructor(codeVersion: string, customSettings: Object = {}, logLevel: logging.Level = logging.Level.INFO) {
         this.storagePath = process.env.TEST_RESOURCES ? process.env.TEST_RESOURCES : path.resolve('test-resources');
         this.extensionsFolder = process.env.EXTENSIONS_FOLDER ? process.env.EXTENSIONS_FOLDER : undefined;
         this.customSettings = customSettings;
         this.codeVersion = codeVersion;
 
-        this.logLevel = VSBrowser.logLevelToLoggingLevel(logLevel);
+        this.logLevel = logLevel;
 
         VSBrowser._instance = this;
     };

--- a/src/suite/runner.ts
+++ b/src/suite/runner.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { VSBrowser, VSBrowserLogLevel } from '../browser';
+import { VSBrowser } from '../browser';
 import * as fs from 'fs-extra';
 import Mocha = require('mocha');
 import * as glob from 'glob';
@@ -8,6 +8,7 @@ import { CodeUtil } from '../util/codeUtil';
 import * as path from 'path';
 import * as yaml from 'js-yaml';
 import sanitize = require('sanitize-filename');
+import { logging } from 'selenium-webdriver';
 
 /**
  * Mocha runner wrapper
@@ -31,9 +32,10 @@ export class VSRunner {
     /**
      * Set up mocha suite, add vscode instance handling, run tests
      * @param testFilesPattern glob pattern of test files to run
+     * @param logLevel The logging level for the Webdriver
      * @return The exit code of the mocha process
      */
-    runTests(testFilesPattern: string, code: CodeUtil, logLevel: VSBrowserLogLevel = VSBrowserLogLevel.Info): Promise<number> {
+    runTests(testFilesPattern: string, code: CodeUtil, logLevel: logging.Level = logging.Level.INFO): Promise<number> {
         return new Promise(resolve => {
             let self = this;
             let browser: VSBrowser = new VSBrowser(this.codeVersion, this.customSettings, logLevel);

--- a/src/util/codeUtil.ts
+++ b/src/util/codeUtil.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import * as child_process from 'child_process';
 import { VSRunner } from "../suite/runner";
 import { Unpack } from "./unpack";
-import { VSBrowserLogLevel } from "../browser";
+import { logging } from "selenium-webdriver";
 
 export enum ReleaseQuality {
     Stable = 'stable',
@@ -22,15 +22,15 @@ export interface RunOptions {
     cleanup?: boolean;
     /** path to a custom mocha configuration file */
     config?: string;
-    /** logging level of the webdriver */
-    logLevel?: VSBrowserLogLevel;
+    /** logging level of the Webdriver */
+    logLevel?: logging.Level;
 }
 
 /** defaults for the [[RunOptions]] */
 export const DEFAULT_RUN_OPTIONS = {
     vscodeVersion: 'latest',
     settings: '',
-    logLevel: VSBrowserLogLevel.Info
+    logLevel: logging.Level.INFO
 }
 
 /**


### PR DESCRIPTION
The current logic for converting a `VSBrowserLogLevel` to `logging.Level` is broken because `logLevel` is actually a number and `toString()` does not result in the expected strings, but just in '0', '1', etc.
We use a dumb switch instead, which relies less on behavior that is not verifiable by the type checker.