### PR TITLE
Dont click tree items to expand them, use expand instead

### DIFF
--- a/locators/lib/1.37.0.ts
+++ b/locators/lib/1.37.0.ts
@@ -179,7 +179,8 @@ const sideBar = {
     TreeItem: {
         actions: By.className('actions-container'),
         actionLabel: By.className('action-label'),
-        actionTitle: 'title'
+        actionTitle: 'title',
+        twistie: By.className('monaco-tl-twistie')
     },
     DefaultTreeSection: {
         itemRow: By.className('monaco-list-row'),

--- a/page-objects/src/components/sidebar/ViewItem.ts
+++ b/page-objects/src/components/sidebar/ViewItem.ts
@@ -10,7 +10,7 @@ export abstract class ViewItem extends ElementWithContexMenu {
      * Select the item in the view.
      * Note that selecting the item will toggle its expand state when applicable.
      * @returns Promise resolving when the item has been clicked
-     */    
+     */
     async select(): Promise<void> {
         await this.click();
     }
@@ -59,7 +59,7 @@ export abstract class TreeItem extends ViewItem {
     abstract getChildren(): Promise<TreeItem[]>
 
     /**
-     * Finds if the item is expandable/collapsible 
+     * Finds if the item is expandable/collapsible
      * @returns Promise resolving to true/false
      */
     abstract isExpandable(): Promise<boolean>;
@@ -88,7 +88,7 @@ export abstract class TreeItem extends ViewItem {
 
     /**
      * Find all action buttons bound to the view item
-     * 
+     *
      * @returns array of ViewItemAction objects, empty array if item has no
      * actions associated
      */
@@ -101,7 +101,7 @@ export abstract class TreeItem extends ViewItem {
         }
         const actions: ViewItemAction[] = [];
         const items = await container.findElements(TreeItem.locators.TreeItem.actionLabel);
-        
+
         for (const item of items) {
             const label = await item.getAttribute(TreeItem.locators.TreeItem.actionTitle);
             actions.push(new ViewItemAction(label, this));
@@ -112,7 +112,7 @@ export abstract class TreeItem extends ViewItem {
     /**
      * Find action button for view item by label
      * @param label label of the button to search by
-     * 
+     *
      * @returns ViewItemAction object if such button exists, undefined otherwise
      */
     async getActionButton(label: string): Promise<ViewItemAction | undefined> {

--- a/page-objects/src/components/sidebar/ViewItem.ts
+++ b/page-objects/src/components/sidebar/ViewItem.ts
@@ -91,7 +91,7 @@ export abstract class TreeItem extends ViewItem {
      */
     async collapse(): Promise<void> {
         if (await this.isExpandable() && await this.isExpanded()) {
-            await this.click();
+            await (await this.findTwistie()).click();
         }
     }
 
@@ -139,9 +139,8 @@ export abstract class TreeItem extends ViewItem {
      */
     protected async getChildItems(locator: By): Promise<WebElement[]> {
         const items: WebElement[] = [];
-        if (!await this.isExpanded() && this.isExpandable()) {
-            await this.click();
-        }
+        await this.expand();
+
         const rows = await this.enclosingItem.findElements(locator);
         const baseIndex = +await this.getAttribute(TreeItem.locators.ViewSection.index);
         const baseLevel = +await this.getAttribute(TreeItem.locators.ViewSection.level);

--- a/page-objects/src/components/sidebar/ViewItem.ts
+++ b/page-objects/src/components/sidebar/ViewItem.ts
@@ -65,6 +65,15 @@ export abstract class TreeItem extends ViewItem {
     abstract isExpandable(): Promise<boolean>;
 
     /**
+     * Expands the current item, if it can be expanded and is collapsed.
+     */
+    async expand(): Promise<void> {
+        if (await this.isExpandable() && !await this.isExpanded()) {
+            await (await this.findTwistie()).click();
+        }
+    }
+
+    /**
      * Find a child item with the given name
      * @returns Promise resolving to TreeItem object if the child item exists, undefined otherwise
      */
@@ -149,6 +158,10 @@ export abstract class TreeItem extends ViewItem {
         }
 
         return items;
+    }
+
+    protected async findTwistie(): Promise<WebElement> {
+        return await this.findElement(TreeItem.locators.TreeItem.twistie);
     }
 }
 

--- a/page-objects/src/components/sidebar/tree/TreeSection.ts
+++ b/page-objects/src/components/sidebar/tree/TreeSection.ts
@@ -7,7 +7,7 @@ import { TreeItem } from "../ViewItem";
 export abstract class TreeSection extends ViewSection {
     async openItem(...path: string[]): Promise<TreeItem[]> {
         let items: TreeItem[] = [];
-    
+
         for (let i = 0; i < path.length; i++) {
             const item = await this.findItem(path[i], i + 1);
             if (await item?.hasChildren() && !await item?.isExpanded()) {

--- a/page-objects/src/locators/locators.ts
+++ b/page-objects/src/locators/locators.ts
@@ -179,7 +179,8 @@ export interface Locators {
     TreeItem: {
         actions: By
         actionLabel: By
-        actionTitle: string
+        actionTitle: string,
+        twistie: By
     }
     DefaultTreeSection: {
         itemRow: By

--- a/test/test-project/src/extension.ts
+++ b/test/test-project/src/extension.ts
@@ -2,6 +2,8 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { TreeView } from './treeView';
 
+export const ERROR_MESSAGE_COMMAND = 'extension.errorMsg';
+
 export function activate(context: vscode.ExtensionContext) {
 	let disposable = vscode.commands.registerCommand('extension.helloWorld', () => {
 		vscode.window.showInformationMessage('Hello World!');
@@ -41,7 +43,7 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(notificationCommand);
 	context.subscriptions.push(quickPickCommand);
 	context.subscriptions.push(vscode.commands.registerCommand('extension.warningMsg', () => vscode.window.showWarningMessage("This is a warning!")));
-	context.subscriptions.push(vscode.commands.registerCommand('extension.errorMsg', () => vscode.window.showErrorMessage("This is an error!")));
+	context.subscriptions.push(vscode.commands.registerCommand(ERROR_MESSAGE_COMMAND, () => vscode.window.showErrorMessage("This is an error!")));
 
 	new TreeView(context);
 

--- a/test/test-project/src/test/xsideBar/customView-test.ts
+++ b/test/test-project/src/test/xsideBar/customView-test.ts
@@ -158,5 +158,20 @@ describe('CustomTreeSection', () => {
             const child = await item.findChildItem('ab');
             expect(child).not.undefined;
         });
+
+        it('expand works', async () => {
+            item = await section.findItem('a');
+            await item.collapse();
+            expect(await item.isExpanded()).to.equal(false);
+            await item.expand();
+            expect(await item.isExpanded()).to.equal(true);
+        });
+
+        it('expand is idempotent', async () => {
+            for (const _i of [1, 2]) {
+                await item.expand();
+                expect(await item.isExpanded()).to.equal(true);
+            }
+        });
     });
 });

--- a/test/test-project/src/treeView.ts
+++ b/test/test-project/src/treeView.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { ERROR_MESSAGE_COMMAND } from './extension';
 
 /**
  * Test tree view as shown in treeview sample extension available at
@@ -15,6 +16,7 @@ type Tree = { [key: string]: Tree | undefined | null };
 
 // structure of the test tree:
 // leafs are keys that are undefined or null. If it is undefined, then its collapsibleState is None, if it null, then it is Collapsed
+// The tree element with the key 'd' is special: it has a command attached to it. It thus cannot be expanded by simply clicking on it, as that just triggers the command.
 const tree: Tree = {
 	'a': {
 		'aa': {
@@ -32,7 +34,11 @@ const tree: Tree = {
 		'ba': undefined,
 		'bb': undefined
 	},
-	'c': null
+	'c': null,
+	'd': {
+		'da': undefined,
+		'db': undefined
+	}
 };
 let nodes = {};
 
@@ -44,6 +50,9 @@ function dataProvider(): vscode.TreeDataProvider<{ key: string }> {
 		getTreeItem: (element: { key: string }): vscode.TreeItem => {
 			const treeItem = getTreeItem(element.key);
 			treeItem.id = element.key;
+			if (element.key === "d") {
+				treeItem.command = { title: "show an error", command: ERROR_MESSAGE_COMMAND };
+			}
 			return treeItem;
 		},
 		getParent: ({ key }: { key: string }): { key: string } => {


### PR DESCRIPTION
Clicking on the tree item only works for tree items that have no command attached to them. For those that have a command bound to them, we have to use `expand()`, as we would otherwise only trigger the command but not expand it.

This PR also adds a regression test for such a case.
