### PR TITLE
Ignore stale items in StatusBar.getItem

### DIFF
--- a/page-objects/src/components/statusBar/StatusBar.ts
+++ b/page-objects/src/components/statusBar/StatusBar.ts
@@ -1,4 +1,4 @@
-import { By, Locator, WebElement } from "selenium-webdriver";
+import { By, Locator, WebElement, error } from "selenium-webdriver";
 import { AbstractElement } from "../AbstractElement";
 import { NotificationsCenter } from "../workbench/NotificationsCenter";
 
@@ -26,8 +26,14 @@ export class StatusBar extends AbstractElement {
     async getItem(title: string): Promise<WebElement | undefined> {
         const items = await this.getItems();
         for (const item of items) {
-            if (await item.getAttribute(StatusBar.locators.StatusBar.itemTitle) === title) {
-                return item;
+            try {
+                if (await item.getAttribute(StatusBar.locators.StatusBar.itemTitle) === title) {
+                    return item;
+                }
+            } catch (err) {
+                if (!(err instanceof error.StaleElementReferenceError)) {
+                    throw err;
+                }
             }
         }
         return undefined;


### PR DESCRIPTION
When searching for a item in the StatusBar, skip items that encounter a `StaleElementReferenceError` instead of throwing an error.

Fixes https://github.com/redhat-developer/vscode-extension-tester/issues/346