### PR TITLE
Only use aria-label for Status Bar itemTitle

### DIFF
--- a/locators/lib/1.37.0.ts
+++ b/locators/lib/1.37.0.ts
@@ -299,7 +299,7 @@ const statusBar = {
         notifications: By.className('notifications-center'),
         bell: By.id('status.notifications'),
         item: By.className('statusbar-item'),
-        itemTitle: 'title'
+        itemTitle: 'aria-label'
     }
 }
 

--- a/locators/lib/1.58.0.ts
+++ b/locators/lib/1.58.0.ts
@@ -1,9 +1,0 @@
-import { LocatorDiff } from "monaco-page-objects";
-
-export const diff: LocatorDiff = {
-    locators: {
-        StatusBar: {
-            itemTitle: 'aria-label'
-        }
-    }
-}

--- a/test/test-project/src/test/statusBar/statusBar-test.ts
+++ b/test/test-project/src/test/statusBar/statusBar-test.ts
@@ -93,7 +93,7 @@ describe('StatusBar', () => {
     });
 
     it('getItem works', async () => {
-        const title = VSBrowser.instance.version >= '1.58.0' ? 'UTF-8' : 'Select Encoding';
+        const title = 'UTF-8';
         const item = await bar.getItem(title);
         expect(item).not.undefined;
     });

--- a/test/test-project/src/test/statusBar/statusBar-test.ts
+++ b/test/test-project/src/test/statusBar/statusBar-test.ts
@@ -93,8 +93,7 @@ describe('StatusBar', () => {
     });
 
     it('getItem works', async () => {
-        const title = 'UTF-8';
-        const item = await bar.getItem(title);
+        const item = await bar.getItem('UTF-8');
         expect(item).not.undefined;
     });
 });


### PR DESCRIPTION
On versions of VSCode prior to 1.58 and when searching for a item in the StatusBar, use the element's aria-label attribute instead of its title attribute. This is because the aria-label is set to the visible text of the item, while the title is set to the tooltip. Not all items have a tooltip making those ones impossible to find.

Fixes https://github.com/redhat-developer/vscode-extension-tester/issues/345