### PR TITLE
Add missing @types/mocha dependency in helloworld example

### DIFF
--- a/sample-projects/helloworld-sample/package.json
+++ b/sample-projects/helloworld-sample/package.json
@@ -37,6 +37,7 @@
 	},
 	"devDependencies": {
 		"@types/chai": "^4.1.7",
+		"@types/mocha": "^9.0.0",
 		"@types/node": "^14.0.0",
 		"@types/vscode": "^1.34.0",
 		"chai": "^4.2.0",


### PR DESCRIPTION
After "npm install" in the vscode-extension-tester/sample-projects/helloworld-sample folder, "npm run compile" gives multiple errors like:
error TS2582: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try npm i --save-dev @types/jest or npm i --save-dev @types/mocha.

Adding "@types/mocha": "^9.0.0" to the "devDependencies" in package.json solves this issue.