### PR TITLE
Close specified group

### DIFF
--- a/page-objects/src/components/editor/EditorView.ts
+++ b/page-objects/src/components/editor/EditorView.ts
@@ -45,7 +45,7 @@ export class EditorView extends AbstractElement {
     async closeAllEditors(groupIndex?: number): Promise<void> {
         let groups = await this.getEditorGroups();
         if (groupIndex !== undefined) {
-            return groups[0].closeAllEditors();
+            return groups[groupIndex].closeAllEditors();
         }
 
         while (groups.length > 0 && (await groups[0].getOpenEditorTitles()).length > 0) {


### PR DESCRIPTION
Noticed that this was only closing the first group when a `groupIndex` was specified.