### PR TITLE
Stabilize TerminalView.getText() method for VSCode insider

### DIFF
--- a/page-objects/src/components/bottomBar/Views.ts
+++ b/page-objects/src/components/bottomBar/Views.ts
@@ -123,7 +123,9 @@ export class TerminalView extends ChannelView {
         const workbench = new Workbench();
         await workbench.executeCommand('terminal select all');
         await workbench.getDriver().sleep(500);
-        await workbench.executeCommand('terminal copy selection');
+        const menu = await this.openContextMenu();
+        await workbench.getDriver().sleep(500);
+        await menu.select('Copy');
         await workbench.getDriver().sleep(500);
         const text = clipboard.readSync();
         clipboard.writeSync('');


### PR DESCRIPTION
Signed-off-by: Dominik Jelinek <djelinek@redhat.com>

This will unblock GH action "Insider" pipeline which was broken

last build with PR change passed - see [Nightly Insiders #540](https://github.com/redhat-developer/vscode-extension-tester/actions/runs/3122882801)