### PR TITLE
Declare locators and page-objects as workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "vscode-extension-tester",
       "version": "5.2.1",
       "license": "Apache-2.0",
+      "workspaces": [
+        "page-objects",
+        "locators"
+      ],
       "dependencies": {
         "@types/selenium-webdriver": "^4.1.9",
         "commander": "^9.4.1",
@@ -43,6 +47,22 @@
         "mocha": ">=5.2.0"
       }
     },
+    "locators": {
+      "name": "vscode-extension-tester-locators",
+      "version": "3.2.1",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^16.18.3",
+        "@types/selenium-webdriver": "^4.1.9",
+        "monaco-page-objects": "file:../page-objects",
+        "rimraf": "^3.0.2",
+        "typescript": "4.9.3"
+      },
+      "peerDependencies": {
+        "monaco-page-objects": "^3.2.1",
+        "selenium-webdriver": "^4.6.1"
+      }
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -75,6 +95,12 @@
         "@types/node": "*",
         "@types/responselike": "^1.0.0"
       }
+    },
+    "node_modules/@types/clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-bdkCSkyVHsgl3Goe1y16T9k6JuQx7SiDREkq728QjKmTZkGJZuS8R3gGcnGzVuGBP0mssKrzM/GlMOQxtip9cg==",
+      "dev": true
     },
     "node_modules/@types/fs-extra": {
       "version": "9.0.13",
@@ -1672,19 +1698,8 @@
       }
     },
     "node_modules/monaco-page-objects": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/monaco-page-objects/-/monaco-page-objects-3.2.1.tgz",
-      "integrity": "sha512-kzzzuLCNl4AdVjaVw+2V2rAF7ueYlepnh5Ssd/clyUwy2WQqLauCIqGkCIZPSvfRlK42y6abXPJ4c8YWPm12TQ==",
-      "dependencies": {
-        "clipboardy": "^2.3.0",
-        "clone-deep": "^4.0.1",
-        "compare-versions": "^5.0.1",
-        "fs-extra": "^10.1.0",
-        "ts-essentials": "^9.3.0"
-      },
-      "peerDependencies": {
-        "selenium-webdriver": "^4.6.1"
-      }
+      "resolved": "page-objects",
+      "link": true
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -2728,13 +2743,8 @@
       }
     },
     "node_modules/vscode-extension-tester-locators": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/vscode-extension-tester-locators/-/vscode-extension-tester-locators-3.2.1.tgz",
-      "integrity": "sha512-wdiEZyRR2BiaZ4meG5TRHTZFkmgy8OLL45Frijv1T/oPmLAIlneL1LL9fQ8a9JvqKVeapvjvPwoXePDoHKPjbQ==",
-      "peerDependencies": {
-        "monaco-page-objects": "^3.2.1",
-        "selenium-webdriver": "^4.6.1"
-      }
+      "resolved": "locators",
+      "link": true
     },
     "node_modules/which": {
       "version": "1.3.1",
@@ -2907,6 +2917,29 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "page-objects": {
+      "name": "monaco-page-objects",
+      "version": "3.2.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clipboardy": "^2.3.0",
+        "clone-deep": "^4.0.1",
+        "compare-versions": "^5.0.1",
+        "fs-extra": "^10.1.0",
+        "ts-essentials": "^9.3.0"
+      },
+      "devDependencies": {
+        "@types/clone-deep": "^4.0.1",
+        "@types/fs-extra": "^9.0.13",
+        "@types/node": "^16.18.3",
+        "@types/selenium-webdriver": "^4.1.9",
+        "rimraf": "^3.0.2",
+        "typescript": "4.9.3"
+      },
+      "peerDependencies": {
+        "selenium-webdriver": "^4.6.1"
+      }
     }
   },
   "dependencies": {
@@ -2933,6 +2966,12 @@
         "@types/node": "*",
         "@types/responselike": "^1.0.0"
       }
+    },
+    "@types/clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-bdkCSkyVHsgl3Goe1y16T9k6JuQx7SiDREkq728QjKmTZkGJZuS8R3gGcnGzVuGBP0mssKrzM/GlMOQxtip9cg==",
+      "dev": true
     },
     "@types/fs-extra": {
       "version": "9.0.13",
@@ -4101,15 +4140,19 @@
       }
     },
     "monaco-page-objects": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/monaco-page-objects/-/monaco-page-objects-3.2.1.tgz",
-      "integrity": "sha512-kzzzuLCNl4AdVjaVw+2V2rAF7ueYlepnh5Ssd/clyUwy2WQqLauCIqGkCIZPSvfRlK42y6abXPJ4c8YWPm12TQ==",
+      "version": "file:page-objects",
       "requires": {
+        "@types/clone-deep": "^4.0.1",
+        "@types/fs-extra": "^9.0.13",
+        "@types/node": "^16.18.3",
+        "@types/selenium-webdriver": "^4.1.9",
         "clipboardy": "^2.3.0",
         "clone-deep": "^4.0.1",
         "compare-versions": "^5.0.1",
         "fs-extra": "^10.1.0",
-        "ts-essentials": "^9.3.0"
+        "rimraf": "^3.0.2",
+        "ts-essentials": "^9.3.0",
+        "typescript": "4.9.3"
       }
     },
     "ms": {
@@ -4907,10 +4950,14 @@
       }
     },
     "vscode-extension-tester-locators": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/vscode-extension-tester-locators/-/vscode-extension-tester-locators-3.2.1.tgz",
-      "integrity": "sha512-wdiEZyRR2BiaZ4meG5TRHTZFkmgy8OLL45Frijv1T/oPmLAIlneL1LL9fQ8a9JvqKVeapvjvPwoXePDoHKPjbQ==",
-      "requires": {}
+      "version": "file:locators",
+      "requires": {
+        "@types/node": "^16.18.3",
+        "@types/selenium-webdriver": "^4.1.9",
+        "monaco-page-objects": "file:../page-objects",
+        "rimraf": "^3.0.2",
+        "typescript": "4.9.3"
+      }
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
     "vscode",
     "extension"
   ],
+  "workspaces": [
+    "page-objects",
+    "locators"
+  ],
   "author": "Red Hat",
   "license": "Apache-2.0",
   "bugs": {


### PR DESCRIPTION
This change should enable yarn to link either locators or page-object
as previously it would complain that these folders are not correctly
declared as workspaces inside parent package.json
