### PR TITLE
Cancel in-progress builds if a PR is updated

### DIFF
--- a/.github/workflows/insiders.yml
+++ b/.github/workflows/insiders.yml
@@ -7,10 +7,13 @@ on:
     branches: [ insider ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
-    
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node
@@ -25,12 +28,12 @@ jobs:
           npm run build
           npm run prepare-test
       - name: Run Tests
-        env: 
+        env:
           CODE_TYPE: insider
         run: |
           sudo apt-get install xvfb
           export DISPLAY=:99.0
-          Xvfb -ac :99 -screen 0 1920x1080x16 & 
+          Xvfb -ac :99 -screen 0 1920x1080x16 &
           npm run ci-test
       - name: Upload screenshots
         uses: actions/upload-artifact@v3

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -15,7 +19,7 @@ jobs:
         node: [ 16 ]
         version:  [ min, 1.71.2, 1.72.2, 1.73.1, max ]
       fail-fast: false
-    
+
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node
@@ -30,12 +34,12 @@ jobs:
           npm run build
           npm run prepare-test
       - name: Run Tests
-        env: 
+        env:
           CODE_VERSION: ${{ matrix.version }}
         run: |
           sudo apt-get install xvfb
           export DISPLAY=:99.0
-          Xvfb -ac :99 -screen 0 1920x1080x16 & 
+          Xvfb -ac :99 -screen 0 1920x1080x16 &
           npm run ci-test
       - name: Upload screenshots
         uses: actions/upload-artifact@v3

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: macos-latest
@@ -15,7 +19,7 @@ jobs:
         node: [ 16 ]
         version: [ max ]
       fail-fast: false
-    
+
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node
@@ -30,7 +34,7 @@ jobs:
           npm run build
           npm run prepare-test
       - name: Run Tests
-        env: 
+        env:
           CODE_VERSION: ${{ matrix.version }}
         run: npm test
       - name: Upload screenshots

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: windows-latest
@@ -15,7 +19,7 @@ jobs:
         node: [ 16 ]
         version: [ max ]
       fail-fast: false
-    
+
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node
@@ -30,7 +34,7 @@ jobs:
           npm run build
           npm run prepare-test
       - name: Run Tests
-        env: 
+        env:
           CODE_VERSION: ${{ matrix.version }}
         run: npm test
       - name: Upload screenshots


### PR DESCRIPTION
This will reduce GHA load and provide faster build results as there
is zero value in running build of a PR revision that was already
outdated.
