### PR TITLE
Fix action locator on ViewTitlePart

### DIFF
--- a/locators/lib/1.71.0.ts
+++ b/locators/lib/1.71.0.ts
@@ -1,0 +1,9 @@
+import { By, LocatorDiff } from "monaco-page-objects";
+export const diff: LocatorDiff = {
+    locators: {
+        ViewTitlePart: {
+            action: By.className(`action-item menu-entry`),
+            actionContstructor: (title: string) => By.xpath(`.//li[@title='${title}']`)
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes in 1.71, the locator of ViewTitleActionButtons

Closes #501