### PR TITLE
Cannot use WebView.switchToFrame() with VSCode 1.74+ when there are several webview opened

### DIFF
--- a/page-objects/src/components/editor/WebView.ts
+++ b/page-objects/src/components/editor/WebView.ts
@@ -55,15 +55,18 @@ export class WebView extends Editor {
         await this.getDriver().switchTo().window(WebView.handle);
 
         const reference = await this.findElement(WebView.locators.EditorView.webView);
-        const container = await this.getDriver().wait(until.elementLocated(WebView.locators.WebView.container(await reference.getAttribute(WebView.locators.WebView.attribute))), 5000);
+        const containers = await this.getDriver().wait(until.elementsLocated(WebView.locators.WebView.container(await reference.getAttribute(WebView.locators.WebView.attribute))), 5000);
 
-        const view = await container.getDriver().wait(async () => {
-            const tries = await container.findElements(WebView.locators.WebView.iframe);
-            if (tries.length > 0) {
-                return tries[0];
+        const view = await containers[0].getDriver().wait(async () => {
+            for (let index = 0; index < containers.length; index++) {
+                const tries = await containers[index].findElements(WebView.locators.WebView.iframe);
+                if (tries.length > 0) {
+                    return tries[0];
+                }
             }
             return undefined;
         }, 5000) as WebElement;
+
         await this.getDriver().switchTo().frame(view);
 
         await this.getDriver().wait(until.elementLocated(WebView.locators.WebView.activeFrame), 5000);

--- a/test/test-project/src/extension.ts
+++ b/test/test-project/src/extension.ts
@@ -27,7 +27,7 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.window.showQuickPick([{ label: 'TestLabel', description: 'Test Description' }]);
 	});
 	let webViewCommand = vscode.commands.registerCommand('extension.webview', async() => {
-		TestView.createOrShow();
+		new TestView();
 	});
 	let notificationCommand = vscode.commands.registerCommand('extension.notification', () => {
 		vscode.window.showInformationMessage('This is a notification', 'Yes', 'No');
@@ -83,36 +83,26 @@ let emptyViewNoContent: boolean = true;
 const emitter = new vscode.EventEmitter<{key: string}>();
 
 class TestView {
-	private static instance: TestView | undefined;
 	public static readonly viewType = 'testView';
 
 	private readonly _panel: vscode.WebviewPanel;
 	private _disposables: vscode.Disposable[] = [];
 
-	public static createOrShow() {
+	constructor() {
 		const column = vscode.window.activeTextEditor
 			? vscode.window.activeTextEditor.viewColumn
 			: undefined;
 
-		if (TestView.instance) {
-			TestView.instance._panel.reveal(column);
-			return;
-		}
-
-		const panel = vscode.window.createWebviewPanel(TestView.viewType, 'Test WebView', column || vscode.ViewColumn.One);
-		TestView.instance = new TestView(panel);
-	}
-
-	private constructor(panel: vscode.WebviewPanel) {
-		this._panel = panel;
-		this.update();
+		const randomWebViewTitle = "Test WebView " + Math.floor(Math.random() * 100);
+		this._panel = vscode.window.createWebviewPanel(TestView.viewType, randomWebViewTitle, column || vscode.ViewColumn.One);
+		this.update(randomWebViewTitle);
 
 		this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
 
 		this._panel.onDidChangeViewState(
 			e => {
 				if (this._panel.visible) {
-					this.update();
+					this.update(randomWebViewTitle);
 				}
 			},
 			null,
@@ -121,7 +111,6 @@ class TestView {
 	}
 
 	public dispose() {
-		TestView.instance = undefined;
 		this._panel.dispose();
 
 		while (this._disposables.length) {
@@ -132,8 +121,8 @@ class TestView {
 		}
 	}
 
-	private update() {
-		this._panel.title = 'Test WebView';
+	private update(title: string) {
+		this._panel.title = title;
 		this._panel.webview.html = `<!DOCTYPE html>
 		<html lang="en">
 		<head>

--- a/test/test-project/src/test/editor/editorView-test.ts
+++ b/test/test-project/src/test/editor/editorView-test.ts
@@ -32,7 +32,13 @@ describe('EditorView', () => {
     });
 
     it('openEditor works with webview editor', async () => {
-        const editor = await view.openEditor('Test WebView') as WebView;
+        let editorTitle: string;
+        (await view.getOpenEditorTitles()).forEach(title => {
+            if(title.startsWith('Test WebView')) {
+                editorTitle = title;
+            }
+        });
+        const editor = await view.openEditor(editorTitle) as WebView;
         expect(editor.findWebElement).not.undefined;
     });
 

--- a/test/test-project/src/test/editor/webView-test.ts
+++ b/test/test-project/src/test/editor/webView-test.ts
@@ -1,30 +1,119 @@
 import { Workbench, EditorView, WebView, By } from 'vscode-extension-tester';
 import { expect } from 'chai';
 
-describe('WebView', () => {
+describe('WebViews', function () {
 
-    let view: WebView;
+    describe('Single WebView', function () {
 
-    before(async function() {
-        this.timeout(8000);
-        await new Workbench().executeCommand('Webview Test');
-        await new Promise((res) => { setTimeout(res, 500); });
-        view = new WebView();
-        await view.switchToFrame();
+        let view: WebView;
+
+        before(async function () {
+            this.timeout(8000);
+            await new Workbench().executeCommand('Webview Test');
+            await new Promise((res) => { setTimeout(res, 500); });
+            view = new WebView();
+            await view.switchToFrame();
+        });
+
+        after(async function () {
+            await view.switchBack();
+            await new EditorView().closeAllEditors();
+        });
+
+        it('findWebElement works', async function () {
+            const element = await view.findWebElement(By.css('h1'));
+            expect(await element.getText()).has.string('This is a web view');
+        });
+
+        it('findWebElements works', async function () {
+            const elements = await view.findWebElements(By.css('h1'));
+            expect(elements.length).equals(1);
+        });
     });
 
-    after(async () => {
-        await view.switchBack();
-        await new EditorView().closeAllEditors();
-    });
+    describe('Several WebViews', function () {
 
-    it('findWebElement works', async () => {
-        const element = await view.findWebElement(By.css('h1'));
-        expect(await element.getText()).has.string('This is a web view');
-    });
+        let view: WebView;
+        let tabs: string[];
 
-    it('findWebElements works', async () => {
-        const elements = await view.findWebElements(By.css('h1'));
-        expect(elements.length).equals(1);
+        before(async function () {
+            await new EditorView().closeAllEditors();
+        });
+
+        before(async function () {
+            this.timeout(10000);
+
+            const workbench = new Workbench();
+
+            await workbench.executeCommand('Webview Test');
+            await new Promise((res) => { setTimeout(res, 500); });
+
+            await workbench.executeCommand('Webview Test');
+            await new Promise((res) => { setTimeout(res, 500); });
+
+            await workbench.executeCommand('Webview Test');
+            await new Promise((res) => { setTimeout(res, 500); });
+
+            tabs = await new EditorView().getOpenEditorTitles();
+        });
+
+        describe('First WebView', function () {
+
+            before(async function () {
+                await new EditorView().openEditor(tabs[0]);
+            });
+
+            switchToFrame();
+            runTests();
+            clean();
+        });
+
+        describe('Second WebView', async function () {
+
+            before(async function () {
+                await new EditorView().openEditor(tabs[1]);
+            });
+
+            switchToFrame();
+            runTests();
+            clean();
+        });
+
+        describe('Third WebView', async function () {
+
+            before(async function () {
+                await new EditorView().openEditor(tabs[2]);
+            });
+
+            switchToFrame();
+            runTests();
+            clean();
+        });
+
+        async function switchToFrame() {
+            before(async function () {
+                view = new WebView();
+                await view.switchToFrame();
+            });
+        }
+
+        async function runTests() {
+            it('findWebElement works', async function () {
+                const element = await view.findWebElement(By.css('h1'));
+                expect(await element.getText()).has.string('This is a web view');
+            });
+
+            it('findWebElements works', async function () {
+                const elements = await view.findWebElements(By.css('h1'));
+                expect(elements.length).equals(1);
+            });
+        }
+
+        async function clean() {
+            after(async function () {
+                await view.switchBack();
+            });
+        }
+
     });
 });


### PR DESCRIPTION
Signed-off-by: Dominik Jelinek <djelinek@redhat.com>

Relates to #545 