### PR TITLE
Add new xpath for quick pick index in 1.76

### DIFF
--- a/locators/lib/1.76.0.ts
+++ b/locators/lib/1.76.0.ts
@@ -1,0 +1,10 @@
+import { LocatorDiff } from "monaco-page-objects";
+import { By } from "selenium-webdriver";
+
+export const diff: LocatorDiff = {
+    locators: {
+        Input: {
+            quickPickIndex: (index: number) => By.xpath(`.//div[@role='checkbox' and @data-index='${index}']`)
+        }
+    }
+}


### PR DESCRIPTION
Updates the xpath for quick pick items in VS Code 1.76, I wouldn't class this as adding support for 1.76 however though as I'm not sure if this is the only change, it's just the only change that the tests on my project needed to get working