### PR TITLE
Add EditorAction Page Object

### DIFF
--- a/locators/lib/1.76.0.ts
+++ b/locators/lib/1.76.0.ts
@@ -1,0 +1,8 @@
+import { LocatorDiff } from "monaco-page-objects";
+export const diff: LocatorDiff = {
+    locators: {
+        EditorView: {
+            attribute: 'aria-label'
+        }
+    }
+}

--- a/page-objects/src/components/editor/EditorAction.ts
+++ b/page-objects/src/components/editor/EditorAction.ts
@@ -1,0 +1,16 @@
+import { EditorGroup } from "./EditorView";
+import { AbstractElement } from "../AbstractElement";
+import { WebElement } from "../..";
+
+export class EditorAction extends AbstractElement {
+    constructor(element: WebElement, parent: EditorGroup) {
+        super(element, parent);
+    }
+
+    /**
+     * Get text description of the action.
+     */
+    async getTitle(): Promise<string> {
+        return this.getAttribute(EditorAction.locators.EditorView.attribute);
+    }
+}

--- a/page-objects/src/index.ts
+++ b/page-objects/src/index.ts
@@ -40,6 +40,7 @@ export * from './components/bottomBar/Views';
 export * from './components/statusBar/StatusBar';
 
 export * from './components/editor/EditorView';
+export * from './components/editor/EditorAction';
 export * from './components/editor/Breakpoint';
 export * from './components/editor/TextEditor';
 export * from './components/editor/Editor';

--- a/test/test-project/src/test/editor/editorView-test.ts
+++ b/test/test-project/src/test/editor/editorView-test.ts
@@ -88,9 +88,14 @@ describe('EditorView', function () {
         expect(actions).not.empty;
     });
 
-    it('getAction works', async function () {
+    it('getAction(title: string) works', async function () {
         const action = await view.getAction('More Actions...');
-        expect(action).not.undefined;
+        expect(await action.getTitle()).equal('More Actions...');
+    });
+
+    it('getAction(predicate: PredicateFunction) works', async function () {
+        const action = await view.getAction(async (action) => await action.getTitle() === 'More Actions...');
+        expect(await action.getTitle()).equal('More Actions...');
     });
 
     it('Editor getAction works', async function () {


### PR DESCRIPTION
Currently, one must call getAttribute to get Editor Action Button label which is not ideal. Also, by adding this feature it will be possible to use predicate that is more flexible than title matching.