### PR TITLE
Add 'disabled' check for vscode components

### DIFF
--- a/locators/lib/1.37.0.ts
+++ b/locators/lib/1.37.0.ts
@@ -1,6 +1,12 @@
 import { By, WebElement } from "selenium-webdriver";
 import { Locators, hasClass, hasNotClass } from "monaco-page-objects";
 
+const abstractElement = {
+    AbstractElement: {
+        enabled: hasNotClass("disabled")
+    }
+}
+
 const activityBar = {
     ActivityBar: {
         constructor: By.id('workbench.parts.activitybar'),
@@ -415,6 +421,7 @@ const welcome = {
  * All available locators for vscode version 1.37.0
  */
 export const locators: Locators = {
+    ...abstractElement,
     ...activityBar,
     ...bottomBar,
     ...editor,

--- a/page-objects/src/components/AbstractElement.ts
+++ b/page-objects/src/components/AbstractElement.ts
@@ -39,6 +39,10 @@ export abstract class AbstractElement extends WebElement {
         this.enclosingItem = item;
     }
 
+    async isEnabled(): Promise<boolean> {
+        return await super.isEnabled() && AbstractElement.locators.AbstractElement.enabled(this);
+    }
+
     /**
      * Wait for the element to become visible
      * @param timeout custom timeout for the wait

--- a/page-objects/src/locators/locators.ts
+++ b/page-objects/src/locators/locators.ts
@@ -1,10 +1,17 @@
 import { By, WebElement } from "selenium-webdriver";
 import { DeepPartial } from 'ts-essentials';
 
+type WebElementFunction<T> = (element: WebElement) => T | PromiseLike<T>;
+
 /**
  * Type definitions for all used locators
  */
 export interface Locators {
+    // AbstractElement properties
+    AbstractElement: {
+        enabled: WebElementFunction<boolean>
+    }
+
     // Activity Bar
     ActivityBar: {
         constructor: By
@@ -104,12 +111,12 @@ export interface Locators {
             pauseSelector: By
             generalSelector: By
             properties: {
-                enabled: (el: WebElement) => Promise<boolean>
+                enabled: WebElementFunction<boolean>
                 line: {
                     selector: By
-                    number: (line: WebElement) => Promise<number>
+                    number: WebElementFunction<number>
                 }
-                paused: (el: WebElement) => Promise<boolean>
+                paused: WebElementFunction<boolean>
             }
         }
         editorContainer: By


### PR DESCRIPTION
Currently, only Selenium enabled check is in place. However, the Selenium check does not verify whether an element is disabled by other means than standard way.