### PR TITLE
Add timeout to InputBox's create function

### DIFF
--- a/page-objects/src/components/workbench/input/InputBox.ts
+++ b/page-objects/src/components/workbench/input/InputBox.ts
@@ -12,6 +12,7 @@ export class InputBox extends Input {
     /**
      * Construct a new InputBox instance after waiting for its underlying element to exist
      * Use when an input box is scheduled to appear.
+     * @param timeout max time to wait in milliseconds, default 5000
      */
     static async create(timeout: number = 5000): Promise<InputBox> {
         await InputBox.driver.wait(until.elementLocated(InputBox.locators.InputBox.constructor), timeout);

--- a/page-objects/src/components/workbench/input/InputBox.ts
+++ b/page-objects/src/components/workbench/input/InputBox.ts
@@ -13,8 +13,8 @@ export class InputBox extends Input {
      * Construct a new InputBox instance after waiting for its underlying element to exist
      * Use when an input box is scheduled to appear.
      */
-    static async create(): Promise<InputBox> {
-        await InputBox.driver.wait(until.elementLocated(InputBox.locators.InputBox.constructor), 5000);
+    static async create(timeout: number = 5000): Promise<InputBox> {
+        await InputBox.driver.wait(until.elementLocated(InputBox.locators.InputBox.constructor), timeout);
         return new InputBox().wait();
     }
 


### PR DESCRIPTION
This lack in the API was a reason for flakiness in our tests, and I thought this would be appropriate as it is with other functions

closes https://github.com/redhat-developer/vscode-extension-tester/issues/821