### PR TITLE
Add multipple breakpoints to editor

### DIFF
--- a/page-objects/src/components/editor/TextEditor.ts
+++ b/page-objects/src/components/editor/TextEditor.ts
@@ -13,6 +13,7 @@ export class BreakpointError extends Error { }
  * Page object representing the active text editor
  */
 export class TextEditor extends Editor {
+    breakPoints: number[] = [];
 
     /**
      * Find whether the active editor has unsaved changes
@@ -433,15 +434,18 @@ export class TextEditor extends Editor {
         const breakpointContainer = TextEditor.versionInfo.version >= '1.80.0' ? await this.findElement(By.className('glyph-margin-widgets')) : lineOverlay;
         const breakPoint = await breakpointContainer.findElements(TextEditor.locators.TextEditor.breakpoint.generalSelector);
         if (breakPoint.length > 0) {
-            await breakPoint[0].click();
-            await new Promise(res => setTimeout(res, 200));
-            return false;
+            if (this.breakPoints.indexOf(line) != -1) {
+                await breakPoint[this.breakPoints.indexOf(line)].click();
+                await new Promise(res => setTimeout(res, 200));
+                this.breakPoints.splice(this.breakPoints.indexOf(line), 1);
+                return false;
+            }
         }
-
         const noBreak = await breakpointContainer.findElements(TextEditor.locators.TextEditor.debugHint);
         if (noBreak.length > 0) {
             await noBreak[0].click();
             await new Promise(res => setTimeout(res, 200));
+            this.breakPoints.push(line);
             return true;
         }
         return false;

--- a/test/test-project/src/test/debug/debug-test.ts
+++ b/test/test-project/src/test/debug/debug-test.ts
@@ -68,7 +68,12 @@ describe('Debugging', function () {
             await new Promise(res => setTimeout(res, 5000));
         });
 
-        it('set a breakpoint', async function () {
+        it('set first breakpoint', async function () {
+            const result = await editor.toggleBreakpoint(line + 1);
+            expect(result).to.be.true;
+        });
+
+        it('set second breakpoint', async function () {
             const result = await editor.toggleBreakpoint(line);
             expect(result).to.be.true;
         });
@@ -221,7 +226,12 @@ describe('Debugging', function () {
             await editor.getDriver().wait(until.elementIsNotVisible(debugBar));
         });
 
-        it('remove the breakpoint', async function () {
+        it('remove the second breakpoint', async function () {
+            const result = await editor.toggleBreakpoint(line + 1);
+            expect(result).to.be.false;
+        });
+
+        it('remove the first breakpoint', async function () {
             const result = await editor.toggleBreakpoint(line);
             expect(result).to.be.false;
         });


### PR DESCRIPTION
Just an idea to hold info about toggled breakpoints in the text editor object attribute 

Will be glad to read feedback and better ideas

fix #904 

---

Before submitting your PR, please review the following checklist:

- [X] **CONSIDER** adding a new test if your PR resolves an issue.
- [X] **DO** keep pull requests small so they can be easily reviewed.
- [X] **DO** make sure tests pass.
- [ ] **DO** make sure any public APIs changes are documented.
- [X] **DO** make sure not to introduce any compiler warnings.

Before merging the PR:
- [ ] **CHECK** continous integration of main branch is green.
- [ ] **CHECK** pull request check job is green.
- [ ] **CHECK** all pull request questions/requests are resolved.
- [ ] **WAIT** till PR is approved by at least 1 committer.
