### PR TITLE
Reverted dependabots update to got 14 since it requires node 20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1485,17 +1485,6 @@
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true
     },
-    "node_modules/@sindresorhus/is": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-6.2.0.tgz",
-      "integrity": "sha512-yM/IGPkVnYGblhDosFBwq0ZGdnVSBkNV4onUtipGMOjZd4kB6GAu3ys91aftSbyMHh6A2GPdt+KDI5NoWP63MQ==",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/is?sponsor=1"
-      }
-    },
     "node_modules/@szmarczak/http-timer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
@@ -4425,14 +4414,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/form-data-encoder": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-4.0.2.tgz",
-      "integrity": "sha512-KQVhvhK8ZkWzxKxOr56CPulAhH3dobtuQ4+hNQ+HekH/Wp5gSOafqRAeTphQUJAIk0GBvHZgJ2ZGRWd5kphMuw==",
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -4830,41 +4811,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/got": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-14.2.1.tgz",
-      "integrity": "sha512-KOaPMremmsvx6l9BLC04LYE6ZFW4x7e4HkTe3LwBmtuYYQwpeS4XKqzhubTIkaQ1Nr+eXxeori0zuwupXMovBQ==",
-      "dependencies": {
-        "@sindresorhus/is": "^6.1.0",
-        "@szmarczak/http-timer": "^5.0.1",
-        "cacheable-lookup": "^7.0.0",
-        "cacheable-request": "^10.2.14",
-        "decompress-response": "^6.0.0",
-        "form-data-encoder": "^4.0.2",
-        "get-stream": "^8.0.1",
-        "http2-wrapper": "^2.2.1",
-        "lowercase-keys": "^3.0.0",
-        "p-cancelable": "^4.0.1",
-        "responselike": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/got?sponsor=1"
-      }
-    },
-    "node_modules/got/node_modules/get-stream": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/graceful-fs": {
@@ -7889,14 +7835,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/p-cancelable": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-4.0.1.tgz",
-      "integrity": "sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==",
-      "engines": {
-        "node": ">=14.16"
       }
     },
     "node_modules/p-finally": {
@@ -11093,7 +11031,7 @@
         "compare-versions": "^6.1.0",
         "fs-extra": "^11.2.0",
         "glob": "^10.3.12",
-        "got": "^14.2.1",
+        "got": "^13.0.0",
         "hpagent": "^1.2.0",
         "js-yaml": "^4.1.0",
         "sanitize-filename": "^1.6.3",
@@ -11106,6 +11044,68 @@
       "peerDependencies": {
         "mocha": ">=5.2.0",
         "typescript": ">=4.6.2"
+      }
+    },
+    "packages/extester/node_modules/@sindresorhus/is": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
+      "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "packages/extester/node_modules/form-data-encoder": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
+      "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+      "engines": {
+        "node": ">= 14.17"
+      }
+    },
+    "packages/extester/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/extester/node_modules/got": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-13.0.0.tgz",
+      "integrity": "sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==",
+      "dependencies": {
+        "@sindresorhus/is": "^5.2.0",
+        "@szmarczak/http-timer": "^5.0.1",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^10.2.8",
+        "decompress-response": "^6.0.0",
+        "form-data-encoder": "^2.1.2",
+        "get-stream": "^6.0.1",
+        "http2-wrapper": "^2.1.10",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^3.0.0",
+        "responselike": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "packages/extester/node_modules/p-cancelable": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
+      "engines": {
+        "node": ">=12.20"
       }
     },
     "packages/locators": {

--- a/packages/extester/package.json
+++ b/packages/extester/package.json
@@ -63,7 +63,7 @@
     "compare-versions": "^6.1.0",
     "fs-extra": "^11.2.0",
     "glob": "^10.3.12",
-    "got": "^14.2.1",
+    "got": "^13.0.0",
     "hpagent": "^1.2.0",
     "js-yaml": "^4.1.0",
     "sanitize-filename": "^1.6.3",


### PR DESCRIPTION
This reverts 20eb715 (#1197)

@dependabot upgraded to got 14, but that [now requires node 20](https://github.com/sindresorhus/got/releases/tag/v14.0.0). ExTester has just moved to node18 (thanks for that), but as is explained in the readme, it's not ready for node20.

During install of the latest version of extester you would get this message:

```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'got@14.2.1',
npm WARN EBADENGINE   required: { node: '>=20' },
npm WARN EBADENGINE   current: { node: 'v18.19.1', npm: '10.2.4' }
npm WARN EBADENGINE }
```

So I thought to help out to make a PR with that dependency reverted, and maybe tell dependabot to not try to update this, the next time it comes around.


Before submitting your PR, please review the following checklist:

- [x] **CONSIDER** adding a new test if your PR resolves an issue.
- [x] **DO** keep pull requests small so they can be easily reviewed.
- [x] **DO** make sure tests pass.
- [x] **DO** make sure any public APIs changes are documented.
- [x] **DO** make sure not to introduce any compiler warnings.

Before merging the PR:

- [ ] **CHECK** continuous integration of `main` branch is green.
- [ ] **CHECK** pull request check job is green.
- [ ] **CHECK** all pull request questions/requests are resolved.
- [ ] **WAIT** till PR is approved by at least 1 committer.
