### PR TITLE
chore: reformat code when using vscode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "editor.codeActionsOnSave": ["source.fixAll.eslint"],
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true
+}


### PR DESCRIPTION
This fixes a problem with current contributors that use vscode would
produce changes that are not passing CI/CD pipelines due to prettier
and eslint config, even if they run `npm run test` locally before
creating the pull-request.

Example of problems:
- spaces being used for identation on typescript source files
- JSON files not being formatted with expected identation (lerna does
  not lint `.vscode/settings.json` but prettied from CI does.

Before submitting your PR, please review the following checklist:

- [ ] **CONSIDER** adding a new test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure tests pass.
- [ ] **DO** make sure any public APIs changes are documented.
- [ ] **DO** make sure not to introduce any compiler warnings.

Before merging the PR:

- [ ] **CHECK** continuous integration of `main` branch is green.
- [ ] **CHECK** pull request check job is green.
- [ ] **CHECK** all pull request questions/requests are resolved.
- [ ] **WAIT** till PR is approved by at least 1 committer.
