### PR TITLE
fix(page-objects): wait for clipboard in TextView.getText()

### DIFF
--- a/packages/page-objects/src/components/bottomBar/AbstractViews.ts
+++ b/packages/page-objects/src/components/bottomBar/AbstractViews.ts
@@ -96,6 +96,19 @@ export abstract class TextView extends ChannelView {
 			const textarea = await self.findElement(ChannelView.locators.BottomBarViews.textArea);
 			await textarea.sendKeys(Key.chord(TextView.ctlKey, 'a'));
 			await textarea.sendKeys(Key.chord(TextView.ctlKey, 'c'));
+			// Wait for clipboard operation to complete
+			// Fixes issue https://github.com/redhat-developer/vscode-extension-tester/issues/2214
+			await self.getWaitHelper().forCondition(
+				async () => {
+					try {
+						const currentClip = clipboard.readSync();
+						return currentClip !== originalClipboard || currentClip.length > 0;
+					} catch {
+						return false;
+					}
+				},
+				{ timeout: 2000, pollInterval: 50, message: 'Clipboard copy operation did not complete' },
+			);
 			const text = clipboard.readSync();
 			// workaround as we are getting "element click intercepted" during the send keys actions.
 			// await textarea.click();


### PR DESCRIPTION
## Description
Fixes `OutputView.getText()` returning clipboard contents instead of actual output text on VS Code 1.108+. The copy operation is async and needs to wait for completion before reading the clipboard.

This mirrors the fix already present in `TextEditor.getText()`.

Fixes #2214

## Checklist

Before submitting your PR, please review the following checklist:

- [x] **CONSIDER** adding a new test if your PR resolves an issue.
  - *Existing test `getText returns all current text` in `views.test.ts` already covers this functionality and now passes.*
- [x] **DO** keep pull requests small so they can be easily reviewed.
  - *Single file change, 13 lines added.*
- [x] **DO** make sure tests pass.
  - *Ran `npm run test:build` locally - OutputView tests pass. Other failures are pre-existing issues unrelated to this change.*
- [x] **DO** make sure any public APIs changes are documented.
  - *No API changes - this is a bug fix to existing behavior.*
- [x] **DO** make sure not to introduce any compiler warnings.
  - *Build passes with `npm run build` - no warnings introduced.*

Before merging the PR:

- [ ] **CHECK** continuous integration of `main` branch is green.
- [ ] **CHECK** pull request check job is green.
- [ ] **CHECK** all pull request questions/requests are resolved.
- [ ] **WAIT** till PR is approved by at least 1 committer.