### PR TITLE
fix: handle EBUSY/EPERM when cleaning settings dir on Windows

### DIFF
--- a/packages/extester/src/browser.ts
+++ b/packages/extester/src/browser.ts
@@ -62,7 +62,16 @@ export class VSBrowser {
 	async start(codePath: string): Promise<VSBrowser> {
 		const userSettings = path.join(this.storagePath, 'settings', 'User');
 		if (fs.existsSync(userSettings)) {
-			fs.removeSync(path.join(this.storagePath, 'settings'));
+			try {
+				fs.removeSync(path.join(this.storagePath, 'settings'));
+			} catch (e: unknown) {
+				const code = (e as NodeJS.ErrnoException).code;
+				if (code === 'EBUSY' || code === 'EPERM') {
+					console.warn(`Could not fully clean settings dir (${code}), continuing anyway.`);
+				} else {
+					throw e;
+				}
+			}
 		}
 
 		let defaultSettings = {


### PR DESCRIPTION
## Description

`VSBrowser.start()` calls `fs.removeSync()` on the entire `settings` directory before each test run. On Windows, if a previous VS Code/chromedriver process did not shut down cleanly (e.g. test runner crashed or was killed with Ctrl+C), it may still hold a lock on log files inside `settings/logs/`. This causes `fs.removeSync` to throw an `EBUSY` error, crashing the entire test run before it even starts.

This is a non-critical cleanup operation — the `settings` directory is recreated immediately after with `fs.mkdirpSync` and `fs.writeJSONSync` — so a failure here should not be fatal.

## Root Cause

Windows uses mandatory file locking: if any process has a file handle open, no other process can delete it. Unlike Unix systems, where `unlink` succeeds even on open files, Windows returns `EBUSY` or `EPERM`.

When a test run is interrupted (Ctrl+C, crash, kill), the spawned VS Code instance and its child processes may not be terminated. These zombie processes keep handles open on log files like `settings/logs/.../main.log`, which makes the next `fs.removeSync('settings')` fail.

## Error

```
EBUSY: resource busy or locked, unlink 'C:\Users\...\test-resources\settings\logs\...\main.log'
```

This causes `TypeError: Cannot read properties of undefined (reading 'manage')` downstream because the browser never starts.

## Fix

Wrap the `fs.removeSync` call in a try-catch that tolerates `EBUSY`/`EPERM` errors. The settings directory is recreated on the very next lines, so a partial cleanup is perfectly safe.

## Environment where reproduced

- **OS:** Windows 10 (10.0.26100)
- **Node.js:** 22.x
- **vscode-extension-tester:** 8.22.0
- **VS Code:** 1.109.5 (latest stable, but not version-specific)