### PR TITLE
fix(page-objects): `selectText` for tab indentation

### DIFF
--- a/packages/page-objects/src/components/editor/TextEditor.ts
+++ b/packages/page-objects/src/components/editor/TextEditor.ts
@@ -248,7 +248,7 @@ export class TextEditor extends Editor {
 			throw new Error(`Text '${text}' not found`);
 		}
 
-		await this.moveCursor(lineNum, column);
+		await this.setCursor(lineNum, column);
 
 		let actions = this.getDriver().actions();
 		await actions.clear();
@@ -545,12 +545,16 @@ export class TextEditor extends Editor {
 		let column = -1;
 		let found = 0;
 		const lines = (await this.getText()).split('\n');
+		const tabSize = await this.getTabSize();
 
 		for (let i = 0; i < lines.length; i++) {
 			let searchIndex = -1; // start at the beginning of the line
 			while ((searchIndex = lines[i].indexOf(text, searchIndex)) > -1) {
 				found++;
-				column = searchIndex + 1;
+				// Compute offset for tabs
+				const nTabs = lines[i].substring(0, searchIndex + 1).split('\t').length - 1;
+				const tabOffset = nTabs * (tabSize - 1); // 1 character per tab has already been counted ('\t') - now offset for the tab size
+				column = searchIndex + 1 + tabOffset;
 				line = i + 1;
 				if (found >= occurrence) {
 					return [line, column];
@@ -618,6 +622,13 @@ export class TextEditor extends Editor {
 			coords.push(+c);
 		}
 		return [coords[0], coords[1]];
+	}
+
+	private async getTabSize(): Promise<number> {
+		const statusBar = new StatusBar();
+		const indent = await statusBar.getCurrentIndentation();
+		const matches = <RegExpMatchArray>indent.match(/\d+/g);
+		return +matches[0];
 	}
 
 	/**

--- a/tests/test-project/src/test/editor/textEditor.test.ts
+++ b/tests/test-project/src/test/editor/textEditor.test.ts
@@ -244,7 +244,7 @@ describe('TextEditor', function () {
 			const ew = new EditorView();
 			const editors = await ew.getOpenEditorTitles();
 			editor = (await ew.openEditor(editors[0])) as TextEditor;
-			await editor.setText('aline\nbline\ncline\ndline\nnope\neline1 eline2\nnope again\nfline');
+			await editor.setText('aline\n    bline\n\tcline\ndline\nnope\neline1 eline2\nnope again\nfline');
 		});
 
 		it('getLineOfText works', async function () {
@@ -286,8 +286,14 @@ describe('TextEditor', function () {
 			expect(cursor).to.deep.equal([6, 13]);
 		});
 
-		it('selected text can be get', async function () {
+		it('selected text can be get (spaces)', async function () {
 			const text = 'bline';
+			await editor.selectText(text);
+			expect(await editor.getSelectedText()).equals(text);
+		});
+
+		it('selected text can be get (tabs)', async function () {
+			const text = 'cline';
 			await editor.selectText(text);
 			expect(await editor.getSelectedText()).equals(text);
 		});


### PR DESCRIPTION
This PR fixes a bug where text selection would not work if the text is preceded by tabs on the same line (typical with tab indentation). It incidentally improves the performance of `selectText` by jumping to the start of the text (using `setCursor`) instead of scrolling line-by-line (using `moveCursor`), like https://github.com/redhat-developer/vscode-extension-tester/pull/2410 does for other public functions.

Closes #2406.

Before submitting your PR, please review the following checklist:

- [x] **CONSIDER** adding a new test if your PR resolves an issue.
- [x] **DO** keep pull requests small so they can be easily reviewed.
- [x] **DO** make sure tests pass.
- [x] **DO** make sure any public APIs changes are documented.
- [x] **DO** make sure not to introduce any compiler warnings.

Before merging the PR:

- [x] **CHECK** continuous integration of `main` branch is green.
- [x] **CHECK** pull request check job is green.
- [x] **CHECK** all pull request questions/requests are resolved.
- [x] **WAIT** till PR is approved by at least 1 committer.
