### PR TITLE
Replace `moveCursor` by `setCursor` for speed.

### DIFF
--- a/docs/TextEditor.md
+++ b/docs/TextEditor.md
@@ -40,7 +40,6 @@ await editor.formatDocument();
 // move the cursor to the given coordinates
 await editor.moveCursor(3, 6);
 // set cursor to given position using command prompt :Ln,Col
-// Note: the setCursor approach is not properly working for tabs indentation in VS Code text editor, see https://github.com/microsoft/vscode/issues/198780
 await editor.setCursor(2, 5);
 // get the current cursor coordinates as number array [x,y]
 const coords = await editor.getCoordinates();

--- a/packages/page-objects/src/components/editor/TextEditor.ts
+++ b/packages/page-objects/src/components/editor/TextEditor.ts
@@ -341,7 +341,7 @@ export class TextEditor extends Editor {
 	 * @returns Promise resolving when the text is typed in
 	 */
 	async typeTextAt(line: number, column: number, text: string): Promise<void> {
-		await this.moveCursor(line, column);
+		await this.setCursor(line, column);
 		await this.typeText(text);
 	}
 

--- a/tests/test-project/src/test/editor/textEditor.test.ts
+++ b/tests/test-project/src/test/editor/textEditor.test.ts
@@ -229,7 +229,7 @@ describe('TextEditor', function () {
 					[2, 12],
 					[3, 15],
 				]) {
-					(param.indent === 'tabs' ? it.skip : it)(`set cursor to position [Ln ${coor[0]}, Col ${coor[1]}]`, async function () {
+					it(`set cursor to position [Ln ${coor[0]}, Col ${coor[1]}]`, async function () {
 						this.timeout(30000);
 						await editor.setCursor(coor[0], coor[1]);
 						expect(await editor.getCoordinates()).to.deep.equal(coor);


### PR DESCRIPTION
In large files, `setCursor` is a lot faster than `moveCursor` (constant speed vs. linear in the size of the file). Since
github.com/microsoft/vscode/issues/198780 seems to have been fixed for recent VS Code versions, `setCursor` is now usable for tab-indented files as well.

Before submitting your PR, please review the following checklist:

- [x] **CONSIDER** adding a new test if your PR resolves an issue.
- [x] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure tests pass.
- [x] **DO** make sure any public APIs changes are documented.
- [x] **DO** make sure not to introduce any compiler warnings.

Before merging the PR:

- [x] **CHECK** continuous integration of `main` branch is green.
- [x] **CHECK** pull request check job is green.
- [x] **CHECK** all pull request questions/requests are resolved.
- [x] **WAIT** till PR is approved by at least 1 committer.
