### PR TITLE
fix: skip VS Code welcome screens on launch

### DIFF
--- a/packages/extester/src/browser.ts
+++ b/packages/extester/src/browser.ts
@@ -112,7 +112,8 @@ export class VSBrowser {
 			args.push(`--extensionDevelopmentPath=${process.env.EXTENSION_DEV_PATH}`);
 		}
 
-		let options = new Options().setChromeBinaryPath(codePath).addArguments(...args) as any;
+		const extraArgs = ['--skip-welcome', '--skip-sessions-welcome', '--skip-release-notes'];
+		let options = new Options().setChromeBinaryPath(codePath).addArguments(...args, ...extraArgs) as any;
 		options['options_'].windowTypes = ['webview'];
 		options = options as Options;
 


### PR DESCRIPTION
Fixes #2345

Adds `--skip-welcome`, `--skip-sessions-welcome`, and `--skip-release-notes` when launching VS Code so welcome/onboarding UI does not block ExTester runs on newer VS Code versions.

Implements the minimal change discussed in https://github.com/redhat-developer/vscode-extension-tester/issues/2345#issuecomment-4616073540.

I thought about adding the ability to re-enable the welcome screens or pass custom VS Code launch arguments, but felt that it was over-engineering. This can be done in a follow up if this becomes a feature request by users.


------------



Before submitting your PR, please review the following checklist:

- [ ] **CONSIDER** adding a new test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure tests pass.
- [ ] **DO** make sure any public APIs changes are documented.
- [ ] **DO** make sure not to introduce any compiler warnings.

Before merging the PR:

- [ ] **CHECK** continuous integration of `main` branch is green.
- [ ] **CHECK** pull request check job is green.
- [ ] **CHECK** all pull request questions/requests are resolved.
- [ ] **WAIT** till PR is approved by at least 1 committer.
