### PR TITLE
feat(extester-runner): add clear, delete and reveal commands to Logs and Screenshots views

### DIFF
--- a/docs/ExtesterRunner.md
+++ b/docs/ExtesterRunner.md
@@ -40,10 +40,11 @@ The extension integrates into VS Code's Activity Bar and provides three main vie
 3. **Test, Logs and Screenshots Management**
    - Automatic refresh of views when test files change
    - Provides quick navigation to test source code
-   - Displays screenshots from test runs with automatic refresh
-   - Provides quick access to view captured screenshots
-   - Maintains and organizes test logs with refresh
-   - Enables quick opening of log files
+   - Displays screenshots and logs sorted newest-first so the latest run is always at the top
+   - Timestamp-named run folders show a human-readable date/time label (e.g. `Jan 15, 2025, 14:30:22`) with the raw folder name as secondary text
+   - **Clear all** — removes the entire contents of the Logs or Screenshots directory in one click (with confirmation)
+   - **Delete individual item** — removes a single file or folder from either view (inline trash icon or right-click > Delete, with confirmation)
+   - **Reveal in File Explorer** — opens the Logs or Screenshots root directory, or any individual item, in the OS file manager (Finder on macOS, Explorer on Windows)
 
 ### Configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13595,9 +13595,9 @@
       "version": "0.2.0-SNAPSHOT",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/parser": "^7.29.2",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0"
+        "@babel/parser": "^7.29.8",
+        "@babel/traverse": "^7.29.8",
+        "@babel/types": "^7.29.8"
       },
       "devDependencies": {
         "@types/babel__traverse": "^7.28.0",

--- a/packages/extester-runner/features.txt
+++ b/packages/extester-runner/features.txt
@@ -43,22 +43,40 @@ Folder structure from logs is available inside
     - all folders are listed
     - empty folders don't have expand button
     - if no folder nor file is available, info message is showed inside TreeView
+Folders are sorted newest-first (by mtime)
+Timestamp-named folders (YYYY-MM-DD_HH-mm-ss) display a human-readable label with raw name as description
 Clicking on filename opens file in editor on line 0
 If new file/folder is created, explorer will update itself
 If file/folder is deleted, explorer will update itself
 If file/folder is changed, explorer will update itself
-Clicking on Refresh Test buttons will update explorer manually
+Clicking on Refresh button will update explorer manually
+Reveal in File Explorer button (folder-opened icon) opens logs directory in OS file manager
+    - if directory doesn't exist, info message is shown
+Clear Logs button (trash icon) removes all content from logs directory after confirmation
+    - confirmation dialog is shown before deletion
+Trash icon is available per-item on hover
+    - click deletes that specific file or folder (with confirmation)
+Right-click on item shows context menu with Delete and Reveal in File Explorer options
 Collapse All button is available
     - if no folder nor file is present, button is not clickable [TODO]
 
 ** Screenshots view **
-Screenshots structure from logs is available inside
+Screenshots structure is available inside
     - if no screenshot is available, info message is showed inside TreeView
+Folders are sorted newest-first (by mtime)
+Timestamp-named folders (YYYY-MM-DD_HH-mm-ss) display a human-readable label with raw name as description
 Clicking on filename opens screenshot
 If new screenshot is created, explorer will update itself
 If screenshot is deleted, explorer will update itself
 If screenshot is changed, explorer will update itself
-Clicking on Refresh Screenshots buttons will update explorer manually
+Clicking on Refresh Screenshots button will update explorer manually
+Reveal in File Explorer button (folder-opened icon) opens screenshots directory in OS file manager
+    - if directory doesn't exist, info message is shown
+Clear Screenshots button (trash icon) removes all content from screenshots directory after confirmation
+    - confirmation dialog is shown before deletion
+Trash icon is available per-item on hover
+    - click deletes that specific file or folder (with confirmation)
+Right-click on item shows context menu with Delete and Reveal in File Explorer options
 
 ** Settings ** 
 Settings are split into two categories - View Settings and Command Line Settings
@@ -73,7 +91,7 @@ Command Line Settings:
         - value is used to create path for running tests
         - 'out' is default value
     Root folder specifies root directory
-        - may be undefinde
+        - may be undefined
         - basically it's the part removed from path of .ts file while creating output .js path
     Temp Folder: 
         - if empty, default TMP_DIR location is used
@@ -84,7 +102,7 @@ Command Line Settings:
 Logs View settings:
     Hide Empty Log Folders:
         - when active, only folders with content are showed in Logs view
-Walkthrought: 
+Walkthrough: 
     Configure Root and Output Directories
         - links leads to relative workspace setting
     Configure Test File Pattern
@@ -95,11 +113,11 @@ Walkthrought:
         - links leads to relative workspace setting
     Additional Arguments
         - links leads to relative workspace setting
-    Addiutional Configuration Options
+    Additional Configuration Options
         - links leads to relative workspace setting
 
 ** Issues **
-Walkthrought is automatically showed only at first install, when extension is reinstalled, no walkthrought is showed (but it's accesible manually).
+Walkthrough is automatically showed only at first install, when extension is reinstalled, no walkthrough is showed (but it's accessible manually).
 
 ** To improve **
 Configuration of root and out can be read from tsconfig.json. 

--- a/packages/extester-runner/package.json
+++ b/packages/extester-runner/package.json
@@ -272,6 +272,58 @@
         "icon": "$(refresh)",
         "tooltip": "Refresh list of screenshots.",
         "category": "ExTester Runner"
+      },
+      {
+        "command": "extester-runner.clearLogs",
+        "title": "Clear Logs",
+        "icon": "$(trash)",
+        "tooltip": "Remove all log files.",
+        "category": "ExTester Runner"
+      },
+      {
+        "command": "extester-runner.clearScreenshots",
+        "title": "Clear Screenshots",
+        "icon": "$(trash)",
+        "tooltip": "Remove all screenshot files.",
+        "category": "ExTester Runner"
+      },
+      {
+        "command": "extester-runner.deleteLogsItem",
+        "title": "Delete",
+        "icon": "$(trash)",
+        "category": "ExTester Runner"
+      },
+      {
+        "command": "extester-runner.deleteScreenshotsItem",
+        "title": "Delete",
+        "icon": "$(trash)",
+        "category": "ExTester Runner"
+      },
+      {
+        "command": "extester-runner.revealLogs",
+        "title": "Reveal Logs in File Explorer",
+        "icon": "$(folder-opened)",
+        "tooltip": "Open logs directory in file explorer.",
+        "category": "ExTester Runner"
+      },
+      {
+        "command": "extester-runner.revealScreenshots",
+        "title": "Reveal Screenshots in File Explorer",
+        "icon": "$(folder-opened)",
+        "tooltip": "Open screenshots directory in file explorer.",
+        "category": "ExTester Runner"
+      },
+      {
+        "command": "extester-runner.revealLogsItem",
+        "title": "Reveal in File Explorer",
+        "icon": "$(folder-opened)",
+        "category": "ExTester Runner"
+      },
+      {
+        "command": "extester-runner.revealScreenshotsItem",
+        "title": "Reveal in File Explorer",
+        "icon": "$(folder-opened)",
+        "category": "ExTester Runner"
       }
     ],
     "viewsContainers": {
@@ -326,6 +378,26 @@
           "command": "extester-runner.refreshScreenshots",
           "when": "view == extesterResourcesScreenshotsView",
           "group": "navigation@1"
+        },
+        {
+          "command": "extester-runner.revealLogs",
+          "when": "view == extesterResourcesLogsView",
+          "group": "navigation@2"
+        },
+        {
+          "command": "extester-runner.revealScreenshots",
+          "when": "view == extesterResourcesScreenshotsView",
+          "group": "navigation@2"
+        },
+        {
+          "command": "extester-runner.clearLogs",
+          "when": "view == extesterResourcesLogsView",
+          "group": "navigation@3"
+        },
+        {
+          "command": "extester-runner.clearScreenshots",
+          "when": "view == extesterResourcesScreenshotsView",
+          "group": "navigation@3"
         }
       ],
       "view/item/context": [
@@ -338,6 +410,36 @@
           "command": "extester-runner.runFile",
           "when": "view == extesterView && viewItem == file",
           "group": "inline"
+        },
+        {
+          "command": "extester-runner.deleteLogsItem",
+          "when": "view == extesterResourcesLogsView && (viewItem == logFolder || viewItem == logFile)",
+          "group": "inline"
+        },
+        {
+          "command": "extester-runner.deleteLogsItem",
+          "when": "view == extesterResourcesLogsView && (viewItem == logFolder || viewItem == logFile)",
+          "group": "1_modification"
+        },
+        {
+          "command": "extester-runner.deleteScreenshotsItem",
+          "when": "view == extesterResourcesScreenshotsView && (viewItem == screenshotFolder || viewItem == screenshotFile)",
+          "group": "inline"
+        },
+        {
+          "command": "extester-runner.deleteScreenshotsItem",
+          "when": "view == extesterResourcesScreenshotsView && (viewItem == screenshotFolder || viewItem == screenshotFile)",
+          "group": "1_modification"
+        },
+        {
+          "command": "extester-runner.revealLogsItem",
+          "when": "view == extesterResourcesLogsView && (viewItem == logFolder || viewItem == logFile)",
+          "group": "2_navigation"
+        },
+        {
+          "command": "extester-runner.revealScreenshotsItem",
+          "when": "view == extesterResourcesScreenshotsView && (viewItem == screenshotFolder || viewItem == screenshotFile)",
+          "group": "2_navigation"
         }
       ],
       "commandPalette": [
@@ -351,6 +453,38 @@
         },
         {
           "command": "extester-runner.runAll",
+          "when": "false"
+        },
+        {
+          "command": "extester-runner.clearLogs",
+          "when": "false"
+        },
+        {
+          "command": "extester-runner.clearScreenshots",
+          "when": "false"
+        },
+        {
+          "command": "extester-runner.deleteLogsItem",
+          "when": "false"
+        },
+        {
+          "command": "extester-runner.deleteScreenshotsItem",
+          "when": "false"
+        },
+        {
+          "command": "extester-runner.revealLogs",
+          "when": "false"
+        },
+        {
+          "command": "extester-runner.revealScreenshots",
+          "when": "false"
+        },
+        {
+          "command": "extester-runner.revealLogsItem",
+          "when": "false"
+        },
+        {
+          "command": "extester-runner.revealScreenshotsItem",
           "when": "false"
         }
       ]
@@ -376,8 +510,8 @@
     "vscode-extension-tester": "*"
   },
   "dependencies": {
-    "@babel/parser": "^7.29.2",
-    "@babel/traverse": "^7.29.0",
-    "@babel/types": "^7.29.0"
+    "@babel/parser": "^7.29.8",
+    "@babel/traverse": "^7.29.8",
+    "@babel/types": "^7.29.8"
   }
 }

--- a/packages/extester-runner/src/commands/logsCommands.ts
+++ b/packages/extester-runner/src/commands/logsCommands.ts
@@ -16,15 +16,12 @@
  */
 
 import * as vscode from 'vscode';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
 import { Logger } from '../logger/logger';
 import { LogsTreeProvider, LogsResourcesItem } from '../providers/logsTreeProvider';
+import { clearResourceDirectory, deleteResourceItem, revealResourceDirectory, revealResourceItem } from './resourceCommands';
 
 /**
  * Registers Logs view related commands for the VS Code extension.
- *
- * This function registers commands for refreshing and clearing the logs tree view.
  *
  * @param {vscode.ExtensionContext} context - The extension context, used for registering commands.
  * @param {LogsTreeProvider} logsDataProvider - The tree data provider responsible for managing the logs view.
@@ -32,81 +29,25 @@ import { LogsTreeProvider, LogsResourcesItem } from '../providers/logsTreeProvid
  */
 export function registerLogsCommands(context: vscode.ExtensionContext, logsDataProvider: LogsTreeProvider, logger: Logger) {
 	context.subscriptions.push(
-		/**
-		 * Registers the `extester-runner.refreshLogs` command.
-		 * This command refreshes the test logs view by triggering an update on the tree data provider.
-		 */
-		vscode.commands.registerCommand('extester-runner.refreshLogs', async () => {
+		vscode.commands.registerCommand('extester-runner.refreshLogs', () => {
 			logger.debug('Command triggered: extester-runner.refreshLogs');
 			logsDataProvider.refresh();
 		}),
-		/**
-		 * Registers the `extester-runner.clearLogs` command.
-		 * Asks for confirmation then removes all files and folders inside the resolved logs directory.
-		 */
-		vscode.commands.registerCommand('extester-runner.clearLogs', async () => {
+		vscode.commands.registerCommand('extester-runner.clearLogs', () => {
 			logger.debug('Command triggered: extester-runner.clearLogs');
-			const answer = await vscode.window.showWarningMessage('Clear all logs? This cannot be undone.', { modal: true }, 'Clear');
-			if (answer !== 'Clear') {
-				return;
-			}
-			const logsPath = logsDataProvider.resolveLogPath();
-			try {
-				await fs.promises.rm(logsPath, { recursive: true, force: true });
-				logger.info(`Cleared logs directory: ${logsPath}`);
-			} catch (error) {
-				logger.error(`Failed to clear logs: ${error}`);
-				vscode.window.showErrorMessage(`Failed to clear logs: ${error}`);
-			}
-			logsDataProvider.refresh();
+			return clearResourceDirectory(logsDataProvider, 'logs', logger);
 		}),
-		/**
-		 * Registers the `extester-runner.deleteLogsItem` command.
-		 * Asks for confirmation then removes the selected file or folder from the logs directory.
-		 */
-		vscode.commands.registerCommand('extester-runner.deleteLogsItem', async (item: LogsResourcesItem) => {
+		vscode.commands.registerCommand('extester-runner.deleteLogsItem', (item: LogsResourcesItem) => {
 			logger.debug(`Command triggered: extester-runner.deleteLogsItem on ${item?.filePath}`);
-			if (!item?.filePath) {
-				return;
-			}
-			const name = path.basename(item.filePath);
-			const answer = await vscode.window.showWarningMessage(`Delete '${name}'? This cannot be undone.`, { modal: true }, 'Delete');
-			if (answer !== 'Delete') {
-				return;
-			}
-			try {
-				await fs.promises.rm(item.filePath, { recursive: true, force: true });
-				logger.info(`Deleted logs item: ${item.filePath}`);
-			} catch (error) {
-				logger.error(`Failed to delete logs item: ${error}`);
-				vscode.window.showErrorMessage(`Failed to delete '${name}': ${error}`);
-			}
-			logsDataProvider.refresh();
+			return deleteResourceItem(item, logsDataProvider, logger);
 		}),
-		/**
-		 * Registers the `extester-runner.revealLogs` command.
-		 * Opens the resolved logs root directory in the OS file manager.
-		 */
-		vscode.commands.registerCommand('extester-runner.revealLogs', async () => {
+		vscode.commands.registerCommand('extester-runner.revealLogs', () => {
 			logger.debug('Command triggered: extester-runner.revealLogs');
-			const logsPath = logsDataProvider.resolveLogPath();
-			if (!fs.existsSync(logsPath)) {
-				vscode.window.showInformationMessage('No logs directory found yet.');
-				return;
-			}
-			await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(logsPath));
+			return revealResourceDirectory(logsDataProvider, logger);
 		}),
-
-		/**
-		 * Registers the `extester-runner.revealLogsItem` command.
-		 * Opens the selected log file or folder in the OS file manager.
-		 */
-		vscode.commands.registerCommand('extester-runner.revealLogsItem', async (item: LogsResourcesItem) => {
+		vscode.commands.registerCommand('extester-runner.revealLogsItem', (item: LogsResourcesItem) => {
 			logger.debug(`Command triggered: extester-runner.revealLogsItem on ${item?.filePath}`);
-			if (!item?.filePath) {
-				return;
-			}
-			await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(item.filePath));
+			return revealResourceItem(item, logger);
 		}),
 	);
 }

--- a/packages/extester-runner/src/commands/logsCommands.ts
+++ b/packages/extester-runner/src/commands/logsCommands.ts
@@ -16,27 +16,97 @@
  */
 
 import * as vscode from 'vscode';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { Logger } from '../logger/logger';
-import { LogsTreeProvider } from '../providers/logsTreeProvider';
+import { LogsTreeProvider, LogsResourcesItem } from '../providers/logsTreeProvider';
 
 /**
  * Registers Logs view related commands for the VS Code extension.
  *
- * This function registers commands for refreshing the logs tree view.
+ * This function registers commands for refreshing and clearing the logs tree view.
  *
  * @param {vscode.ExtensionContext} context - The extension context, used for registering commands.
  * @param {LogsTreeProvider} logsDataProvider - The tree data provider responsible for managing the logs view.
  * @param {Logger} logger - The logging utility for debugging and tracking command execution.
  */
 export function registerLogsCommands(context: vscode.ExtensionContext, logsDataProvider: LogsTreeProvider, logger: Logger) {
-	/**
-	 * Registers the `extester-runner.refreshLogs` command.
-	 * This command refreshes the test logs view by triggering an update on the tree data provider.
-	 */
 	context.subscriptions.push(
+		/**
+		 * Registers the `extester-runner.refreshLogs` command.
+		 * This command refreshes the test logs view by triggering an update on the tree data provider.
+		 */
 		vscode.commands.registerCommand('extester-runner.refreshLogs', async () => {
 			logger.debug('Command triggered: extester-runner.refreshLogs');
 			logsDataProvider.refresh();
+		}),
+		/**
+		 * Registers the `extester-runner.clearLogs` command.
+		 * Asks for confirmation then removes all files and folders inside the resolved logs directory.
+		 */
+		vscode.commands.registerCommand('extester-runner.clearLogs', async () => {
+			logger.debug('Command triggered: extester-runner.clearLogs');
+			const answer = await vscode.window.showWarningMessage('Clear all logs? This cannot be undone.', { modal: true }, 'Clear');
+			if (answer !== 'Clear') {
+				return;
+			}
+			const logsPath = logsDataProvider.resolveLogPath();
+			try {
+				await fs.promises.rm(logsPath, { recursive: true, force: true });
+				logger.info(`Cleared logs directory: ${logsPath}`);
+			} catch (error) {
+				logger.error(`Failed to clear logs: ${error}`);
+				vscode.window.showErrorMessage(`Failed to clear logs: ${error}`);
+			}
+			logsDataProvider.refresh();
+		}),
+		/**
+		 * Registers the `extester-runner.deleteLogsItem` command.
+		 * Asks for confirmation then removes the selected file or folder from the logs directory.
+		 */
+		vscode.commands.registerCommand('extester-runner.deleteLogsItem', async (item: LogsResourcesItem) => {
+			logger.debug(`Command triggered: extester-runner.deleteLogsItem on ${item?.filePath}`);
+			if (!item?.filePath) {
+				return;
+			}
+			const name = path.basename(item.filePath);
+			const answer = await vscode.window.showWarningMessage(`Delete '${name}'? This cannot be undone.`, { modal: true }, 'Delete');
+			if (answer !== 'Delete') {
+				return;
+			}
+			try {
+				await fs.promises.rm(item.filePath, { recursive: true, force: true });
+				logger.info(`Deleted logs item: ${item.filePath}`);
+			} catch (error) {
+				logger.error(`Failed to delete logs item: ${error}`);
+				vscode.window.showErrorMessage(`Failed to delete '${name}': ${error}`);
+			}
+			logsDataProvider.refresh();
+		}),
+		/**
+		 * Registers the `extester-runner.revealLogs` command.
+		 * Opens the resolved logs root directory in the OS file manager.
+		 */
+		vscode.commands.registerCommand('extester-runner.revealLogs', async () => {
+			logger.debug('Command triggered: extester-runner.revealLogs');
+			const logsPath = logsDataProvider.resolveLogPath();
+			if (!fs.existsSync(logsPath)) {
+				vscode.window.showInformationMessage('No logs directory found yet.');
+				return;
+			}
+			await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(logsPath));
+		}),
+
+		/**
+		 * Registers the `extester-runner.revealLogsItem` command.
+		 * Opens the selected log file or folder in the OS file manager.
+		 */
+		vscode.commands.registerCommand('extester-runner.revealLogsItem', async (item: LogsResourcesItem) => {
+			logger.debug(`Command triggered: extester-runner.revealLogsItem on ${item?.filePath}`);
+			if (!item?.filePath) {
+				return;
+			}
+			await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(item.filePath));
 		}),
 	);
 }

--- a/packages/extester-runner/src/commands/resourceCommands.ts
+++ b/packages/extester-runner/src/commands/resourceCommands.ts
@@ -1,0 +1,118 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License", destination); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as vscode from 'vscode';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { Logger } from '../logger/logger';
+
+/**
+ * Minimal interface satisfied by both `LogsTreeProvider` and `ScreenshotsTreeProvider`,
+ * used to avoid duplicating command logic between the two views.
+ */
+export interface ResourceProvider {
+	resolveRootPath(): string;
+	refresh(): void;
+}
+
+/**
+ * Represents a selectable item in a resource tree view (logs or screenshots).
+ * Both `LogsResourcesItem` and `ScreenshotsResourcesItem` satisfy this shape.
+ */
+export interface ResourceItem {
+	filePath: string;
+}
+
+/**
+ * Clears all contents of the provider's root directory after user confirmation.
+ *
+ * @param provider - The tree provider whose root directory will be cleared.
+ * @param label - Display name used in confirmation and error messages (e.g. `"logs"`).
+ * @param logger - Logger instance.
+ */
+export async function clearResourceDirectory(provider: ResourceProvider, label: string, logger: Logger): Promise<void> {
+	const answer = await vscode.window.showWarningMessage(`Clear all ${label}? This cannot be undone.`, { modal: true }, 'Clear');
+	if (answer !== 'Clear') {
+		return;
+	}
+	const dirPath = provider.resolveRootPath();
+	try {
+		await fs.promises.rm(dirPath, { recursive: true, force: true });
+		logger.info(`Cleared ${label} directory: ${dirPath}`);
+	} catch (error) {
+		logger.error(`Failed to clear ${label}: ${error}`);
+		vscode.window.showErrorMessage(`Failed to clear ${label}: ${error}`);
+	}
+	provider.refresh();
+}
+
+/**
+ * Deletes a single file or folder after user confirmation.
+ *
+ * @param item - The tree item to delete. Silently returns if `filePath` is absent.
+ * @param provider - The tree provider to refresh after deletion.
+ * @param logger - Logger instance.
+ */
+export async function deleteResourceItem(item: ResourceItem | undefined, provider: ResourceProvider, logger: Logger): Promise<void> {
+	if (!item?.filePath) {
+		return;
+	}
+	const name = path.basename(item.filePath);
+	const answer = await vscode.window.showWarningMessage(`Delete '${name}'? This cannot be undone.`, { modal: true }, 'Delete');
+	if (answer !== 'Delete') {
+		return;
+	}
+	try {
+		await fs.promises.rm(item.filePath, { recursive: true, force: true });
+		logger.info(`Deleted item: ${item.filePath}`);
+	} catch (error) {
+		logger.error(`Failed to delete item: ${error}`);
+		vscode.window.showErrorMessage(`Failed to delete '${name}': ${error}`);
+	}
+	provider.refresh();
+}
+
+/**
+ * Opens the provider's root directory in the OS file manager.
+ * Shows an informational message if the directory does not exist yet.
+ *
+ * @param provider - The tree provider whose root directory will be revealed.
+ * @param logger - Logger instance.
+ */
+export async function revealResourceDirectory(provider: ResourceProvider, logger: Logger): Promise<void> {
+	const dirPath = provider.resolveRootPath();
+	if (!fs.existsSync(dirPath)) {
+		vscode.window.showInformationMessage('No directory found yet.');
+		return;
+	}
+	logger.debug(`Revealing directory: ${dirPath}`);
+	await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(dirPath));
+}
+
+/**
+ * Opens a specific tree item in the OS file manager.
+ *
+ * @param item - The tree item to reveal. Silently returns if `filePath` is absent.
+ * @param logger - Logger instance.
+ */
+export async function revealResourceItem(item: ResourceItem | undefined, logger: Logger): Promise<void> {
+	if (!item?.filePath) {
+		return;
+	}
+	logger.debug(`Revealing item: ${item.filePath}`);
+	await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(item.filePath));
+}

--- a/packages/extester-runner/src/commands/screenshotsCommands.ts
+++ b/packages/extester-runner/src/commands/screenshotsCommands.ts
@@ -16,15 +16,12 @@
  */
 
 import * as vscode from 'vscode';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
 import { Logger } from '../logger/logger';
 import { ScreenshotsTreeProvider, ScreenshotsResourcesItem } from '../providers/screenshotsTreeProvider';
+import { clearResourceDirectory, deleteResourceItem, revealResourceDirectory, revealResourceItem } from './resourceCommands';
 
 /**
  * Registers Screenshots view related commands for the VS Code extension.
- *
- * This function registers commands for refreshing and clearing the screenshot tree view.
  *
  * @param {vscode.ExtensionContext} context - The extension context, used for registering commands.
  * @param {ScreenshotsTreeProvider} screenshotDataProvider - The tree data provider responsible for managing the screenshot view.
@@ -32,80 +29,25 @@ import { ScreenshotsTreeProvider, ScreenshotsResourcesItem } from '../providers/
  */
 export function registerScreenshotsCommands(context: vscode.ExtensionContext, screenshotDataProvider: ScreenshotsTreeProvider, logger: Logger) {
 	context.subscriptions.push(
-		/**
-		 * Registers the `extester-runner.refreshScreenshots` command.
-		 * This command refreshes the screenshots view by triggering an update on the tree data provider.
-		 */
-		vscode.commands.registerCommand('extester-runner.refreshScreenshots', async () => {
+		vscode.commands.registerCommand('extester-runner.refreshScreenshots', () => {
 			logger.debug('Command triggered: extester-runner.refreshScreenshots');
 			screenshotDataProvider.refresh();
 		}),
-		/**
-		 * Registers the `extester-runner.clearScreenshots` command.
-		 * Asks for confirmation then removes all files and folders inside the resolved screenshots directory.
-		 */
-		vscode.commands.registerCommand('extester-runner.clearScreenshots', async () => {
+		vscode.commands.registerCommand('extester-runner.clearScreenshots', () => {
 			logger.debug('Command triggered: extester-runner.clearScreenshots');
-			const answer = await vscode.window.showWarningMessage('Clear all screenshots? This cannot be undone.', { modal: true }, 'Clear');
-			if (answer !== 'Clear') {
-				return;
-			}
-			const screenshotsPath = screenshotDataProvider.resolveScreenshotsPath();
-			try {
-				await fs.promises.rm(screenshotsPath, { recursive: true, force: true });
-				logger.info(`Cleared screenshots directory: ${screenshotsPath}`);
-			} catch (error) {
-				logger.error(`Failed to clear screenshots: ${error}`);
-				vscode.window.showErrorMessage(`Failed to clear screenshots: ${error}`);
-			}
-			screenshotDataProvider.refresh();
+			return clearResourceDirectory(screenshotDataProvider, 'screenshots', logger);
 		}),
-		/**
-		 * Registers the `extester-runner.deleteScreenshotsItem` command.
-		 * Asks for confirmation then removes the selected file or folder from the screenshots directory.
-		 */
-		vscode.commands.registerCommand('extester-runner.deleteScreenshotsItem', async (item: ScreenshotsResourcesItem) => {
+		vscode.commands.registerCommand('extester-runner.deleteScreenshotsItem', (item: ScreenshotsResourcesItem) => {
 			logger.debug(`Command triggered: extester-runner.deleteScreenshotsItem on ${item?.filePath}`);
-			if (!item?.filePath) {
-				return;
-			}
-			const name = path.basename(item.filePath);
-			const answer = await vscode.window.showWarningMessage(`Delete '${name}'? This cannot be undone.`, { modal: true }, 'Delete');
-			if (answer !== 'Delete') {
-				return;
-			}
-			try {
-				await fs.promises.rm(item.filePath, { recursive: true, force: true });
-				logger.info(`Deleted screenshots item: ${item.filePath}`);
-			} catch (error) {
-				logger.error(`Failed to delete screenshots item: ${error}`);
-				vscode.window.showErrorMessage(`Failed to delete '${name}': ${error}`);
-			}
-			screenshotDataProvider.refresh();
+			return deleteResourceItem(item, screenshotDataProvider, logger);
 		}),
-		/**
-		 * Registers the `extester-runner.revealScreenshots` command.
-		 * Opens the resolved screenshots root directory in the OS file manager.
-		 */
-		vscode.commands.registerCommand('extester-runner.revealScreenshots', async () => {
+		vscode.commands.registerCommand('extester-runner.revealScreenshots', () => {
 			logger.debug('Command triggered: extester-runner.revealScreenshots');
-			const screenshotsPath = screenshotDataProvider.resolveScreenshotsPath();
-			if (!fs.existsSync(screenshotsPath)) {
-				vscode.window.showInformationMessage('No screenshots directory found yet.');
-				return;
-			}
-			await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(screenshotsPath));
+			return revealResourceDirectory(screenshotDataProvider, logger);
 		}),
-		/**
-		 * Registers the `extester-runner.revealScreenshotsItem` command.
-		 * Opens the selected screenshot file or folder in the OS file manager.
-		 */
-		vscode.commands.registerCommand('extester-runner.revealScreenshotsItem', async (item: ScreenshotsResourcesItem) => {
+		vscode.commands.registerCommand('extester-runner.revealScreenshotsItem', (item: ScreenshotsResourcesItem) => {
 			logger.debug(`Command triggered: extester-runner.revealScreenshotsItem on ${item?.filePath}`);
-			if (!item?.filePath) {
-				return;
-			}
-			await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(item.filePath));
+			return revealResourceItem(item, logger);
 		}),
 	);
 }

--- a/packages/extester-runner/src/commands/screenshotsCommands.ts
+++ b/packages/extester-runner/src/commands/screenshotsCommands.ts
@@ -16,27 +16,96 @@
  */
 
 import * as vscode from 'vscode';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { Logger } from '../logger/logger';
-import { ScreenshotsTreeProvider } from '../providers/screenshotsTreeProvider';
+import { ScreenshotsTreeProvider, ScreenshotsResourcesItem } from '../providers/screenshotsTreeProvider';
 
 /**
  * Registers Screenshots view related commands for the VS Code extension.
  *
- * This function registers commands for refreshing the screenshot tree view.
+ * This function registers commands for refreshing and clearing the screenshot tree view.
  *
  * @param {vscode.ExtensionContext} context - The extension context, used for registering commands.
  * @param {ScreenshotsTreeProvider} screenshotDataProvider - The tree data provider responsible for managing the screenshot view.
  * @param {Logger} logger - The logging utility for debugging and tracking command execution.
  */
 export function registerScreenshotsCommands(context: vscode.ExtensionContext, screenshotDataProvider: ScreenshotsTreeProvider, logger: Logger) {
-	/**
-	 * Registers the `extester-runner.refreshScreenshots` command.
-	 * This command refreshes the screenshots view by triggering an update on the tree data provider.
-	 */
 	context.subscriptions.push(
+		/**
+		 * Registers the `extester-runner.refreshScreenshots` command.
+		 * This command refreshes the screenshots view by triggering an update on the tree data provider.
+		 */
 		vscode.commands.registerCommand('extester-runner.refreshScreenshots', async () => {
 			logger.debug('Command triggered: extester-runner.refreshScreenshots');
 			screenshotDataProvider.refresh();
+		}),
+		/**
+		 * Registers the `extester-runner.clearScreenshots` command.
+		 * Asks for confirmation then removes all files and folders inside the resolved screenshots directory.
+		 */
+		vscode.commands.registerCommand('extester-runner.clearScreenshots', async () => {
+			logger.debug('Command triggered: extester-runner.clearScreenshots');
+			const answer = await vscode.window.showWarningMessage('Clear all screenshots? This cannot be undone.', { modal: true }, 'Clear');
+			if (answer !== 'Clear') {
+				return;
+			}
+			const screenshotsPath = screenshotDataProvider.resolveScreenshotsPath();
+			try {
+				await fs.promises.rm(screenshotsPath, { recursive: true, force: true });
+				logger.info(`Cleared screenshots directory: ${screenshotsPath}`);
+			} catch (error) {
+				logger.error(`Failed to clear screenshots: ${error}`);
+				vscode.window.showErrorMessage(`Failed to clear screenshots: ${error}`);
+			}
+			screenshotDataProvider.refresh();
+		}),
+		/**
+		 * Registers the `extester-runner.deleteScreenshotsItem` command.
+		 * Asks for confirmation then removes the selected file or folder from the screenshots directory.
+		 */
+		vscode.commands.registerCommand('extester-runner.deleteScreenshotsItem', async (item: ScreenshotsResourcesItem) => {
+			logger.debug(`Command triggered: extester-runner.deleteScreenshotsItem on ${item?.filePath}`);
+			if (!item?.filePath) {
+				return;
+			}
+			const name = path.basename(item.filePath);
+			const answer = await vscode.window.showWarningMessage(`Delete '${name}'? This cannot be undone.`, { modal: true }, 'Delete');
+			if (answer !== 'Delete') {
+				return;
+			}
+			try {
+				await fs.promises.rm(item.filePath, { recursive: true, force: true });
+				logger.info(`Deleted screenshots item: ${item.filePath}`);
+			} catch (error) {
+				logger.error(`Failed to delete screenshots item: ${error}`);
+				vscode.window.showErrorMessage(`Failed to delete '${name}': ${error}`);
+			}
+			screenshotDataProvider.refresh();
+		}),
+		/**
+		 * Registers the `extester-runner.revealScreenshots` command.
+		 * Opens the resolved screenshots root directory in the OS file manager.
+		 */
+		vscode.commands.registerCommand('extester-runner.revealScreenshots', async () => {
+			logger.debug('Command triggered: extester-runner.revealScreenshots');
+			const screenshotsPath = screenshotDataProvider.resolveScreenshotsPath();
+			if (!fs.existsSync(screenshotsPath)) {
+				vscode.window.showInformationMessage('No screenshots directory found yet.');
+				return;
+			}
+			await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(screenshotsPath));
+		}),
+		/**
+		 * Registers the `extester-runner.revealScreenshotsItem` command.
+		 * Opens the selected screenshot file or folder in the OS file manager.
+		 */
+		vscode.commands.registerCommand('extester-runner.revealScreenshotsItem', async (item: ScreenshotsResourcesItem) => {
+			logger.debug(`Command triggered: extester-runner.revealScreenshotsItem on ${item?.filePath}`);
+			if (!item?.filePath) {
+				return;
+			}
+			await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(item.filePath));
 		}),
 	);
 }

--- a/packages/extester-runner/src/extension.ts
+++ b/packages/extester-runner/src/extension.ts
@@ -63,7 +63,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	logger.debug('Registering screenshot tree view.');
 	vscode.window.createTreeView('extesterResourcesScreenshotsView', {
 		treeDataProvider: screenshotsDataProvider,
-		showCollapseAll: false,
+		showCollapseAll: true,
 	});
 
 	// logs view

--- a/packages/extester-runner/src/providers/logsTreeProvider.ts
+++ b/packages/extester-runner/src/providers/logsTreeProvider.ts
@@ -18,95 +18,25 @@
 import * as vscode from 'vscode';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import * as os from 'node:os';
 import { Logger } from '../logger/logger';
-import { formatTimestampLabel } from '../utils/formatLabel';
+import { ResourceTreeItem, ResourceTreeProvider } from './resourceTreeProvider';
 
 /**
  * Provides a tree view for displaying log files and directories within the ExTester VS Code extension.
- * This class implements vscode.TreeDataProvider<LogsResourcesItem> and is responsible for:
- *  - Scanning and presenting a directory structure containing logs.
- *  - Dynamically updating the view based on configuration settings.
- *  - Allowing users to open log files directly from the tree view.
- *  - Updating the logs tree view when changes occur.
  */
-export class LogsTreeProvider implements vscode.TreeDataProvider<LogsResourcesItem> {
-	private readonly _onDidChangeTreeData = new vscode.EventEmitter<LogsResourcesItem | undefined>();
-	readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
-
-	private readonly logger: Logger;
-
-	/**
-	 * Creates an instance of the `LogsTreeProvider`.
-	 *
-	 * @param {Logger} logger - The logging utility for debugging and tracking file operations.
-	 */
+export class LogsTreeProvider extends ResourceTreeProvider<LogsResourcesItem> {
 	constructor(logger: Logger) {
-		this.logger = logger;
-		this.logger.debug('Initial logs tree provider constructed.');
-		this.refresh();
+		super(logger, 'logs');
 	}
 
-	/**
-	 * Refreshes the logs tree view.
-	 */
-	refresh(): void {
-		this.logger.debug('Refreshing logs tree...');
-		this._onDidChangeTreeData.fire(undefined);
-	}
-
-	/**
-	 * Dynamically resolves the log path used for displaying log files in the tree view.
-	 *
-	 * This ensures that the logs path always reflects the most up-to-date configuration,
-	 * even if the log directory changes during runtime.
-	 *
-	 * @returns {string} The resolved absolute path to the logs directory (`settings/logs`).
-	 */
-	/** Implements {@link ResourceProvider} — delegates to `resolveLogPath`. */
 	resolveRootPath(): string {
 		return this.resolveLogPath();
 	}
 
 	resolveLogPath(): string {
-		const configuration = vscode.workspace.getConfiguration('extesterRunner');
-		const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-
-		const tempDirSettings = configuration.get<string>('tempFolder')?.trim();
-		const envTempDir = process.env.TEST_RESOURCES?.trim();
-
-		let baseTempDir: string | undefined = tempDirSettings ?? envTempDir;
-
-		if (baseTempDir && baseTempDir.length > 0) {
-			baseTempDir = path.isAbsolute(baseTempDir) ? baseTempDir : path.join(workspaceFolder ?? '', baseTempDir);
-		} else {
-			baseTempDir = path.join(process.env.TMPDIR ?? os.tmpdir(), 'test-resources');
-		}
-
-		const finalPath = path.join(baseTempDir, 'settings', 'logs');
-		this.logger.debug('Resolved logs directory: ' + finalPath);
-		return finalPath;
+		return this.resolveBasePath('settings/logs');
 	}
 
-	/**
-	 * Retrieves the `vscode.TreeItem` representation for each log resource item.
-	 *
-	 * @param {LogsResourcesItem} element - The log resource item to display.
-	 * @returns {vscode.TreeItem} - The corresponding tree item.
-	 */
-	getTreeItem(element: LogsResourcesItem): vscode.TreeItem {
-		return element;
-	}
-
-	/**
-	 * Provides child elements for the tree view.
-	 *
-	 * This method scans directories and files under the log resources folder, creating a structured hierarchy.
-	 * It respects the user-configurable setting to optionally hide empty directories.
-	 *
-	 * @param {LogsResourcesItem} [element] - The parent element, if available.
-	 * @returns {Promise<LogsResourcesItem[]>} - A promise resolving to an array of log resource items.
-	 */
 	async getChildren(element?: LogsResourcesItem): Promise<LogsResourcesItem[]> {
 		const dirPath = element ? element.filePath : this.resolveLogPath();
 		const hideEmptyFolders = vscode.workspace.getConfiguration('extesterRunner').get<boolean>('hideEmptyLogFolders', true);
@@ -159,48 +89,31 @@ export class LogsTreeProvider implements vscode.TreeDataProvider<LogsResourcesIt
 /**
  * Represents a tree item in the logs explorer.
  */
-export class LogsResourcesItem extends vscode.TreeItem {
-	/**
-	 * Creates an instance of the `LogsResourcesItem`
-	 * @param {string} label - The label displayed in the tree view.
-	 * @param {string} filePath - The file path associated with this item.
-	 * @param {boolean} isDir - Whether this item represents a folder.
-	 * @param {boolean} isEmpty - Flag to track empty folders.
-	 */
+export class LogsResourcesItem extends ResourceTreeItem {
 	constructor(
-		public label: string,
-		public filePath: string,
-		public isDir: boolean,
-		public isEmpty: boolean,
+		label: string,
+		filePath: string,
+		isDir: boolean,
+		public readonly isEmpty: boolean,
 	) {
-		super(label, isDir && !isEmpty ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None);
+		super(label, filePath, isDir, 'logFolder', 'logFile');
 
-		if (filePath) {
-			this.tooltip = filePath;
-			this.resourceUri = vscode.Uri.file(filePath);
-
-			this.iconPath = isDir ? new vscode.ThemeIcon('symbol-folder') : new vscode.ThemeIcon('file');
-			this.contextValue = isDir ? 'logFolder' : 'logFile';
-
-			// Apply human-readable label for timestamp-named directories.
-			if (isDir) {
-				const formatted = formatTimestampLabel(label);
-				if (formatted) {
-					this.label = formatted.label;
-					this.description = formatted.description;
-				}
-			}
-
-			if (!isDir) {
-				this.command = {
-					command: 'vscode.open',
-					title: 'Open File',
-					arguments: [vscode.Uri.file(filePath)],
-				};
-			}
-		} else {
-			// placeholder item
-			this.iconPath = new vscode.ThemeIcon('warning');
+		// Override collapsible state: empty log directories are not expandable.
+		if (isDir && isEmpty) {
+			this.collapsibleState = vscode.TreeItemCollapsibleState.None;
 		}
+
+		// Log directories use a different icon than the base class default.
+		if (filePath && isDir) {
+			this.iconPath = new vscode.ThemeIcon('symbol-folder');
+		}
+	}
+
+	protected buildOpenCommand(filePath: string): vscode.Command {
+		return {
+			command: 'vscode.open',
+			title: 'Open File',
+			arguments: [vscode.Uri.file(filePath)],
+		};
 	}
 }

--- a/packages/extester-runner/src/providers/logsTreeProvider.ts
+++ b/packages/extester-runner/src/providers/logsTreeProvider.ts
@@ -16,9 +16,11 @@
  */
 
 import * as vscode from 'vscode';
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 import { Logger } from '../logger/logger';
+import { formatTimestampLabel } from '../utils/formatLabel';
 
 /**
  * Provides a tree view for displaying log files and directories within the ExTester VS Code extension.
@@ -61,7 +63,7 @@ export class LogsTreeProvider implements vscode.TreeDataProvider<LogsResourcesIt
 	 *
 	 * @returns {string} The resolved absolute path to the logs directory (`settings/logs`).
 	 */
-	private resolveLogPath(): string {
+	resolveLogPath(): string {
 		const configuration = vscode.workspace.getConfiguration('extesterRunner');
 		const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
 
@@ -73,7 +75,7 @@ export class LogsTreeProvider implements vscode.TreeDataProvider<LogsResourcesIt
 		if (baseTempDir && baseTempDir.length > 0) {
 			baseTempDir = path.isAbsolute(baseTempDir) ? baseTempDir : path.join(workspaceFolder ?? '', baseTempDir);
 		} else {
-			baseTempDir = path.join(process.env.TMPDIR ?? require('os').tmpdir(), 'test-resources');
+			baseTempDir = path.join(process.env.TMPDIR ?? os.tmpdir(), 'test-resources');
 		}
 
 		const finalPath = path.join(baseTempDir, 'settings', 'logs');
@@ -129,6 +131,22 @@ export class LogsTreeProvider implements vscode.TreeDataProvider<LogsResourcesIt
 			return [new LogsResourcesItem('No logs', '', false, true)];
 		}
 
+		// Sort root-level items newest-first by mtime; leave nested items (children of a folder) unsorted.
+		if (!element) {
+			const withMtime = await Promise.all(
+				items.map(async (item) => {
+					try {
+						const stat = await fs.promises.stat(item.filePath);
+						return { item, mtime: stat.mtimeMs };
+					} catch {
+						return { item, mtime: 0 };
+					}
+				}),
+			);
+			withMtime.sort((a, b) => b.mtime - a.mtime);
+			return withMtime.map((x) => x.item);
+		}
+
 		return items;
 	}
 }
@@ -136,7 +154,7 @@ export class LogsTreeProvider implements vscode.TreeDataProvider<LogsResourcesIt
 /**
  * Represents a tree item in the logs explorer.
  */
-class LogsResourcesItem extends vscode.TreeItem {
+export class LogsResourcesItem extends vscode.TreeItem {
 	/**
 	 * Creates an instance of the `LogsResourcesItem`
 	 * @param {string} label - The label displayed in the tree view.
@@ -157,6 +175,16 @@ class LogsResourcesItem extends vscode.TreeItem {
 			this.resourceUri = vscode.Uri.file(filePath);
 
 			this.iconPath = isDir ? new vscode.ThemeIcon('symbol-folder') : new vscode.ThemeIcon('file');
+			this.contextValue = isDir ? 'logFolder' : 'logFile';
+
+			// Apply human-readable label for timestamp-named directories.
+			if (isDir) {
+				const formatted = formatTimestampLabel(label);
+				if (formatted) {
+					this.label = formatted.label;
+					this.description = formatted.description;
+				}
+			}
 
 			if (!isDir) {
 				this.command = {

--- a/packages/extester-runner/src/providers/logsTreeProvider.ts
+++ b/packages/extester-runner/src/providers/logsTreeProvider.ts
@@ -63,6 +63,11 @@ export class LogsTreeProvider implements vscode.TreeDataProvider<LogsResourcesIt
 	 *
 	 * @returns {string} The resolved absolute path to the logs directory (`settings/logs`).
 	 */
+	/** Implements {@link ResourceProvider} — delegates to `resolveLogPath`. */
+	resolveRootPath(): string {
+		return this.resolveLogPath();
+	}
+
 	resolveLogPath(): string {
 		const configuration = vscode.workspace.getConfiguration('extesterRunner');
 		const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;

--- a/packages/extester-runner/src/providers/resourceTreeProvider.ts
+++ b/packages/extester-runner/src/providers/resourceTreeProvider.ts
@@ -1,0 +1,144 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License", destination); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as vscode from 'vscode';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { Logger } from '../logger/logger';
+import { formatTimestampLabel } from '../utils/formatLabel';
+
+/**
+ * Base class for tree items displayed in the Logs and Screenshots views.
+ *
+ * Handles the common setup shared by both views:
+ * - `tooltip` and `resourceUri` from the file path
+ * - Human-readable timestamp label for timestamp-named directories
+ * - Placeholder icon when no path is provided
+ *
+ * Subclasses supply the `contextValue` strings and the open command for files.
+ */
+export abstract class ResourceTreeItem extends vscode.TreeItem {
+	/**
+	 * @param label - Display label (raw folder/file name).
+	 * @param filePath - Absolute path on disk. Empty string for placeholder items.
+	 * @param isDir - Whether this item represents a directory.
+	 * @param folderContextValue - `contextValue` applied to directory items.
+	 * @param fileContextValue - `contextValue` applied to file items.
+	 */
+	constructor(
+		public label: string,
+		public readonly filePath: string,
+		public readonly isDir: boolean,
+		folderContextValue: string,
+		fileContextValue: string,
+	) {
+		super(label, isDir ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None);
+
+		if (filePath) {
+			this.tooltip = filePath;
+			this.resourceUri = vscode.Uri.file(filePath);
+
+			if (isDir) {
+				this.iconPath = vscode.ThemeIcon.Folder;
+				this.contextValue = folderContextValue;
+
+				// Apply human-readable label for timestamp-named directories.
+				const formatted = formatTimestampLabel(label);
+				if (formatted) {
+					this.label = formatted.label;
+					this.description = formatted.description;
+				}
+			} else {
+				this.iconPath = vscode.ThemeIcon.File;
+				this.contextValue = fileContextValue;
+				this.command = this.buildOpenCommand(filePath);
+			}
+		} else {
+			// Placeholder item shown when the directory is empty or missing.
+			this.iconPath = new vscode.ThemeIcon('warning');
+		}
+	}
+
+	/** Returns the VS Code command used to open a file item. Override to customise. */
+	protected abstract buildOpenCommand(filePath: string): vscode.Command;
+}
+
+/**
+ * Abstract base class for the Logs and Screenshots tree providers.
+ *
+ * Handles the common infrastructure shared by both views:
+ * - EventEmitter / `onDidChangeTreeData`
+ * - `refresh()` and `getTreeItem()`
+ * - Base-path resolution from `extesterRunner.tempFolder`, `TEST_RESOURCES`, or OS temp dir
+ *
+ * Subclasses supply:
+ * - `pathSuffix` — the sub-path appended to the base temp dir (e.g. `"screenshots"` or `"settings/logs"`)
+ * - `resolveRootPath()` — a public alias used by command handlers
+ */
+export abstract class ResourceTreeProvider<T extends ResourceTreeItem> implements vscode.TreeDataProvider<T> {
+	protected readonly _onDidChangeTreeData = new vscode.EventEmitter<T | undefined>();
+	readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+	protected readonly logger: Logger;
+
+	constructor(logger: Logger, debugLabel: string) {
+		this.logger = logger;
+		this.logger.debug(`Initial ${debugLabel} tree provider constructed.`);
+		this.refresh();
+	}
+
+	refresh(): void {
+		this._onDidChangeTreeData.fire(undefined);
+	}
+
+	getTreeItem(element: T): vscode.TreeItem {
+		return element;
+	}
+
+	abstract getChildren(element?: T): Promise<T[]>;
+
+	/**
+	 * Resolves the root directory path for this view.
+	 *
+	 * Priority: `extesterRunner.tempFolder` setting → `TEST_RESOURCES` env var → OS temp dir.
+	 * Relative values are resolved against the first workspace folder.
+	 *
+	 * @param suffix - Sub-path appended to the base temp directory.
+	 */
+	protected resolveBasePath(suffix: string): string {
+		const configuration = vscode.workspace.getConfiguration('extesterRunner');
+		const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+
+		const tempDirSettings = configuration.get<string>('tempFolder')?.trim();
+		const envTempDir = process.env.TEST_RESOURCES?.trim();
+
+		let baseTempDir: string | undefined = tempDirSettings ?? envTempDir;
+
+		if (baseTempDir && baseTempDir.length > 0) {
+			baseTempDir = path.isAbsolute(baseTempDir) ? baseTempDir : path.join(workspaceFolder ?? '', baseTempDir);
+		} else {
+			baseTempDir = path.join(process.env.TMPDIR ?? os.tmpdir(), 'test-resources');
+		}
+
+		const finalPath = path.join(baseTempDir, ...suffix.split('/'));
+		this.logger.debug(`Resolved ${suffix} directory: ${finalPath}`);
+		return finalPath;
+	}
+
+	/** Public alias required by the {@link ResourceProvider} interface used in command handlers. */
+	abstract resolveRootPath(): string;
+}

--- a/packages/extester-runner/src/providers/screenshotsTreeProvider.ts
+++ b/packages/extester-runner/src/providers/screenshotsTreeProvider.ts
@@ -18,93 +18,25 @@
 import * as vscode from 'vscode';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import * as os from 'node:os';
 import { Logger } from '../logger/logger';
-import { formatTimestampLabel } from '../utils/formatLabel';
+import { ResourceTreeItem, ResourceTreeProvider } from './resourceTreeProvider';
 
 /**
  * Provides a tree view for displaying screenshots within the ExTester VS Code extension.
- * This class implements vscode.TreeDataProvider<ScreenshotsResourcesItem> and is responsible for:
- *  - Scanning and presenting a directory structure containing screenshots.
- *  - Allowing users to open screenshots files directly from the tree view.
- *  - Updating the screenshots tree view when changes occur.
  */
-export class ScreenshotsTreeProvider implements vscode.TreeDataProvider<ScreenshotsResourcesItem> {
-	private readonly _onDidChangeTreeData = new vscode.EventEmitter<ScreenshotsResourcesItem | undefined>();
-	readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
-
-	private readonly logger: Logger;
-
-	/**
-	 * Creates an instance of the `ScreenshotsTreeProvider`.
-	 *
-	 * @param {Logger} logger - The logging utility for debugging and tracking file operations.
-	 */
+export class ScreenshotsTreeProvider extends ResourceTreeProvider<ScreenshotsResourcesItem> {
 	constructor(logger: Logger) {
-		this.logger = logger;
-		this.logger.debug('Initial screenshots tree provider constructed.');
-		this.refresh();
+		super(logger, 'screenshots');
 	}
 
-	/**
-	 * Refreshes the logs tree view.
-	 */
-	refresh(): void {
-		this.logger.debug('Refreshing screenshots tree...');
-		this._onDidChangeTreeData.fire(undefined);
-	}
-
-	/**
-	 * Dynamically resolves the screenshots path used for displaying screenshots files in the tree view.
-	 *
-	 * This ensures that the screenshots path always reflects the most up-to-date configuration,
-	 * even if the log directory changes during runtime.
-	 *
-	 * @returns {string} The resolved absolute path to the screenshots directory (`screenshots`).
-	 */
-	/** Implements {@link ResourceProvider} — delegates to `resolveScreenshotsPath`. */
 	resolveRootPath(): string {
 		return this.resolveScreenshotsPath();
 	}
 
 	resolveScreenshotsPath(): string {
-		const configuration = vscode.workspace.getConfiguration('extesterRunner');
-		const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-
-		const tempDirSettings = configuration.get<string>('tempFolder')?.trim();
-		const envTempDir = process.env.TEST_RESOURCES?.trim();
-
-		let baseTempDir: string | undefined = tempDirSettings ?? envTempDir;
-
-		if (baseTempDir && baseTempDir.length > 0) {
-			baseTempDir = path.isAbsolute(baseTempDir) ? baseTempDir : path.join(workspaceFolder ?? '', baseTempDir);
-		} else {
-			baseTempDir = path.join(process.env.TMPDIR ?? os.tmpdir(), 'test-resources');
-		}
-
-		const finalPath = path.join(baseTempDir, 'screenshots');
-		this.logger.debug('Resolved screenshots directory: ' + finalPath);
-		return finalPath;
+		return this.resolveBasePath('screenshots');
 	}
 
-	/**
-	 * Retrieves the `vscode.TreeItem` representation for each log resource item.
-	 *
-	 * @param {ScreenshotsResourcesItem} element - The screenshot item to display.
-	 * @returns {vscode.TreeItem} - The corresponding tree item.
-	 */
-	getTreeItem(element: ScreenshotsResourcesItem): vscode.TreeItem {
-		return element;
-	}
-
-	/**
-	 * Retrieves child elements for the screenshots tree view.
-	 *
-	 * In case the directory doesn't exist or is empty, an empty array is returned.
-	 *
-	 * @param {ScreenshotsResourcesItem} [element] - Optional parent tree element to retrieve children from.
-	 * @returns {Promise<ScreenshotsResourcesItem[]>} A promise resolving to an array of tree items representing screenshots.
-	 */
 	async getChildren(element?: ScreenshotsResourcesItem): Promise<ScreenshotsResourcesItem[]> {
 		const dirPath = element ? element.filePath : this.resolveScreenshotsPath();
 
@@ -126,10 +58,8 @@ export class ScreenshotsTreeProvider implements vscode.TreeDataProvider<Screensh
 			const stat = await fs.promises.stat(fullPath);
 
 			if (stat.isDirectory()) {
-				// This is a timestamp folder
 				itemsWithStat.push({ item: new ScreenshotsResourcesItem(file, fullPath, true), mtime: stat.mtimeMs });
 			} else if (stat.isFile()) {
-				// This is a screenshot file
 				itemsWithStat.push({ item: new ScreenshotsResourcesItem(file, fullPath, false), mtime: stat.mtimeMs });
 			}
 		}
@@ -140,10 +70,10 @@ export class ScreenshotsTreeProvider implements vscode.TreeDataProvider<Screensh
 		} else {
 			// Nested level: directories first, then alphabetical.
 			itemsWithStat.sort((a, b) => {
-				if (a.item.isDirectory !== b.item.isDirectory) {
-					return a.item.isDirectory ? -1 : 1;
+				if (a.item.isDir !== b.item.isDir) {
+					return a.item.isDir ? -1 : 1;
 				}
-				return a.item.label.localeCompare(b.item.label);
+				return String(a.item.label).localeCompare(String(b.item.label));
 			});
 		}
 
@@ -154,49 +84,16 @@ export class ScreenshotsTreeProvider implements vscode.TreeDataProvider<Screensh
 /**
  * Represents a tree item in the screenshots explorer.
  */
-export class ScreenshotsResourcesItem extends vscode.TreeItem {
-	/**
-	 * Creates an instance of the `ScreenshotsResourcesItem`
-	 * @param {string} label - The label displayed in the tree view.
-	 * @param {string} filePath - The file path associated with this item.
-	 * @param {boolean} isDirectory - Indicates whether this item represents a directory.
-	 */
-	constructor(
-		public readonly label: string,
-		public readonly filePath: string,
-		public readonly isDirectory: boolean,
-	) {
-		super(label, isDirectory ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None);
+export class ScreenshotsResourcesItem extends ResourceTreeItem {
+	constructor(label: string, filePath: string, isDir: boolean) {
+		super(label, filePath, isDir, 'screenshotFolder', 'screenshotFile');
+	}
 
-		if (filePath) {
-			this.tooltip = filePath;
-			this.resourceUri = vscode.Uri.file(filePath);
-
-			if (isDirectory) {
-				// This is a timestamp folder
-				this.iconPath = vscode.ThemeIcon.Folder;
-				this.contextValue = 'screenshotFolder';
-
-				// Apply human-readable label for timestamp-named directories.
-				const formatted = formatTimestampLabel(label);
-				if (formatted) {
-					this.label = formatted.label;
-					this.description = formatted.description;
-				}
-			} else {
-				// This is a screenshot file
-				this.iconPath = vscode.ThemeIcon.File;
-				this.contextValue = 'screenshotFile';
-
-				this.command = {
-					command: 'vscode.open',
-					title: 'Open Screenshot',
-					arguments: [vscode.Uri.file(filePath)],
-				};
-			}
-		} else {
-			// placeholder item
-			this.iconPath = new vscode.ThemeIcon('warning');
-		}
+	protected buildOpenCommand(filePath: string): vscode.Command {
+		return {
+			command: 'vscode.open',
+			title: 'Open Screenshot',
+			arguments: [vscode.Uri.file(filePath)],
+		};
 	}
 }

--- a/packages/extester-runner/src/providers/screenshotsTreeProvider.ts
+++ b/packages/extester-runner/src/providers/screenshotsTreeProvider.ts
@@ -16,9 +16,11 @@
  */
 
 import * as vscode from 'vscode';
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 import { Logger } from '../logger/logger';
+import { formatTimestampLabel } from '../utils/formatLabel';
 
 /**
  * Provides a tree view for displaying screenshots within the ExTester VS Code extension.
@@ -60,7 +62,7 @@ export class ScreenshotsTreeProvider implements vscode.TreeDataProvider<Screensh
 	 *
 	 * @returns {string} The resolved absolute path to the screenshots directory (`screenshots`).
 	 */
-	private resolveScreenshotsPath(): string {
+	resolveScreenshotsPath(): string {
 		const configuration = vscode.workspace.getConfiguration('extesterRunner');
 		const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
 
@@ -72,7 +74,7 @@ export class ScreenshotsTreeProvider implements vscode.TreeDataProvider<Screensh
 		if (baseTempDir && baseTempDir.length > 0) {
 			baseTempDir = path.isAbsolute(baseTempDir) ? baseTempDir : path.join(workspaceFolder ?? '', baseTempDir);
 		} else {
-			baseTempDir = path.join(process.env.TMPDIR ?? require('os').tmpdir(), 'test-resources');
+			baseTempDir = path.join(process.env.TMPDIR ?? os.tmpdir(), 'test-resources');
 		}
 
 		const finalPath = path.join(baseTempDir, 'screenshots');
@@ -112,7 +114,7 @@ export class ScreenshotsTreeProvider implements vscode.TreeDataProvider<Screensh
 			return [new ScreenshotsResourcesItem('No screenshots', '', false)];
 		}
 
-		const items: ScreenshotsResourcesItem[] = [];
+		const itemsWithStat: { item: ScreenshotsResourcesItem; mtime: number }[] = [];
 
 		for (const file of files) {
 			const fullPath = path.join(dirPath, file);
@@ -120,29 +122,34 @@ export class ScreenshotsTreeProvider implements vscode.TreeDataProvider<Screensh
 
 			if (stat.isDirectory()) {
 				// This is a timestamp folder
-				items.push(new ScreenshotsResourcesItem(file, fullPath, true));
+				itemsWithStat.push({ item: new ScreenshotsResourcesItem(file, fullPath, true), mtime: stat.mtimeMs });
 			} else if (stat.isFile()) {
 				// This is a screenshot file
-				items.push(new ScreenshotsResourcesItem(file, fullPath, false));
+				itemsWithStat.push({ item: new ScreenshotsResourcesItem(file, fullPath, false), mtime: stat.mtimeMs });
 			}
 		}
 
-		// Sort directories first, then files
-		items.sort((a, b) => {
-			if (a.isDirectory !== b.isDirectory) {
-				return a.isDirectory ? -1 : 1;
-			}
-			return a.label.localeCompare(b.label);
-		});
+		if (!element) {
+			// Root level: sort newest-first by mtime.
+			itemsWithStat.sort((a, b) => b.mtime - a.mtime);
+		} else {
+			// Nested level: directories first, then alphabetical.
+			itemsWithStat.sort((a, b) => {
+				if (a.item.isDirectory !== b.item.isDirectory) {
+					return a.item.isDirectory ? -1 : 1;
+				}
+				return a.item.label.localeCompare(b.item.label);
+			});
+		}
 
-		return items;
+		return itemsWithStat.map((x) => x.item);
 	}
 }
 
 /**
  * Represents a tree item in the screenshots explorer.
  */
-class ScreenshotsResourcesItem extends vscode.TreeItem {
+export class ScreenshotsResourcesItem extends vscode.TreeItem {
 	/**
 	 * Creates an instance of the `ScreenshotsResourcesItem`
 	 * @param {string} label - The label displayed in the tree view.
@@ -164,6 +171,13 @@ class ScreenshotsResourcesItem extends vscode.TreeItem {
 				// This is a timestamp folder
 				this.iconPath = vscode.ThemeIcon.Folder;
 				this.contextValue = 'screenshotFolder';
+
+				// Apply human-readable label for timestamp-named directories.
+				const formatted = formatTimestampLabel(label);
+				if (formatted) {
+					this.label = formatted.label;
+					this.description = formatted.description;
+				}
 			} else {
 				// This is a screenshot file
 				this.iconPath = vscode.ThemeIcon.File;

--- a/packages/extester-runner/src/providers/screenshotsTreeProvider.ts
+++ b/packages/extester-runner/src/providers/screenshotsTreeProvider.ts
@@ -62,6 +62,11 @@ export class ScreenshotsTreeProvider implements vscode.TreeDataProvider<Screensh
 	 *
 	 * @returns {string} The resolved absolute path to the screenshots directory (`screenshots`).
 	 */
+	/** Implements {@link ResourceProvider} — delegates to `resolveScreenshotsPath`. */
+	resolveRootPath(): string {
+		return this.resolveScreenshotsPath();
+	}
+
 	resolveScreenshotsPath(): string {
 		const configuration = vscode.workspace.getConfiguration('extesterRunner');
 		const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;

--- a/packages/extester-runner/src/ui-test/02_testView.test.ts
+++ b/packages/extester-runner/src/ui-test/02_testView.test.ts
@@ -32,7 +32,11 @@ import {
 	COLLAPSE_ALL_BTN,
 	TEST_VIEW_REFRESH_BTN,
 	SCREENSHOTS_VIEW_REFRESH_BTN,
+	SCREENSHOTS_VIEW_REVEAL_BTN,
+	SCREENSHOTS_VIEW_CLEAR_BTN,
 	LOGS_VIEW_REFRESH_BTN,
+	LOGS_VIEW_REVEAL_BTN,
+	LOGS_VIEW_CLEAR_BTN,
 	TEMP_FOLDER_SETTINGS_ID,
 	getSection,
 	updateSettings,
@@ -153,12 +157,21 @@ describe('Empty View Tests', function () {
 		 */
 		it('action buttons are correct', async function () {
 			const actions = await section.getActions();
-			assert.equal(actions.length, 1);
+			assert.equal(actions.length, 4);
 
-			const [refreshBtn] = actions;
+			const [refreshBtn, revealBtn, clearBtn, collapseBtn] = actions;
 
 			assert.equal(await refreshBtn.getLabel(), SCREENSHOTS_VIEW_REFRESH_BTN);
 			assert.equal(await refreshBtn.isEnabled(), true);
+
+			assert.equal(await revealBtn.getLabel(), SCREENSHOTS_VIEW_REVEAL_BTN);
+			assert.equal(await revealBtn.isEnabled(), true);
+
+			assert.equal(await clearBtn.getLabel(), SCREENSHOTS_VIEW_CLEAR_BTN);
+			assert.equal(await clearBtn.isEnabled(), true);
+
+			assert.equal(await collapseBtn.getLabel(), COLLAPSE_ALL_BTN);
+			assert.equal(await collapseBtn.isEnabled(), false);
 		});
 	});
 
@@ -201,12 +214,18 @@ describe('Empty View Tests', function () {
 		 */
 		it('action buttons are correct', async function () {
 			const actions = await section.getActions();
-			assert.equal(actions.length, 2);
+			assert.equal(actions.length, 4);
 
-			const [refreshBtn, collapseBtn] = actions;
+			const [refreshBtn, revealBtn, clearBtn, collapseBtn] = actions;
 
 			assert.equal(await refreshBtn.getLabel(), LOGS_VIEW_REFRESH_BTN);
 			assert.equal(await refreshBtn.isEnabled(), true);
+
+			assert.equal(await revealBtn.getLabel(), LOGS_VIEW_REVEAL_BTN);
+			assert.equal(await revealBtn.isEnabled(), true);
+
+			assert.equal(await clearBtn.getLabel(), LOGS_VIEW_CLEAR_BTN);
+			assert.equal(await clearBtn.isEnabled(), true);
 
 			assert.equal(await collapseBtn.getLabel(), COLLAPSE_ALL_BTN);
 			assert.equal(await collapseBtn.isEnabled(), false);

--- a/packages/extester-runner/src/ui-test/utils/testUtils.ts
+++ b/packages/extester-runner/src/ui-test/utils/testUtils.ts
@@ -57,10 +57,14 @@ export const TEST_VIEW_REFRESH_BTN = 'Refresh Tests';
 export const SCREENSHOTS_VIEW = 'Screenshots';
 export const SCREENSHOTS_VIEW_NO_SCREENSHOTS = 'No screenshots';
 export const SCREENSHOTS_VIEW_REFRESH_BTN = 'Refresh Screenshots';
+export const SCREENSHOTS_VIEW_REVEAL_BTN = 'Reveal Screenshots in File Explorer';
+export const SCREENSHOTS_VIEW_CLEAR_BTN = 'Clear Screenshots';
 
 export const LOGS_VIEW = 'Logs';
 export const LOGS_VIEW_NO_LOGS = 'No logs';
 export const LOGS_VIEW_REFRESH_BTN = 'Refresh Logs';
+export const LOGS_VIEW_REVEAL_BTN = 'Reveal Logs in File Explorer';
+export const LOGS_VIEW_CLEAR_BTN = 'Clear Logs';
 
 export const COLLAPSE_ALL_BTN = 'Collapse All';
 

--- a/packages/extester-runner/src/utils/formatLabel.ts
+++ b/packages/extester-runner/src/utils/formatLabel.ts
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License", destination); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Compact ISO timestamp used by ExTester: `YYYYMMDDTHHmmss` (e.g. `20260803T154330`).
+ */
+const TIMESTAMP_COMPACT_RE = /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})$/;
+
+/**
+ * Dash-underscore timestamp format: `YYYY-MM-DD_HH-mm-ss` (e.g. `2026-08-03_15-43-30`).
+ */
+const TIMESTAMP_DASHED_RE = /^(\d{4})-(\d{2})-(\d{2})_(\d{2})-(\d{2})-(\d{2})$/;
+
+/**
+ * Attempts to parse an ExTester timestamp folder name and returns a human-readable label.
+ *
+ * Recognises two formats:
+ * - Compact ISO:      `YYYYMMDDTHHmmss`     (e.g. `20260803T154330`)
+ * - Dash-underscore:  `YYYY-MM-DD_HH-mm-ss` (e.g. `2026-08-03_15-43-30`)
+ *
+ * The label is formatted using `Date.toLocaleString(undefined, ...)` so the output respects
+ * the user's OS locale automatically — no hardcoded language or separators.
+ *
+ * Returns an object with:
+ * - `label`       — locale-formatted date/time string (e.g. `"Aug 3, 2026, 15:43:30"` on en-US)
+ * - `description` — the original raw folder name, shown as secondary/dimmed text in the tree row
+ *
+ * Returns `null` for names that match neither pattern (displayed unchanged).
+ *
+ * @param name - The folder or file name to format.
+ * @returns A `{ label, description }` pair, or `null` if the name is not a recognised timestamp.
+ */
+export function formatTimestampLabel(name: string): { label: string; description: string } | null {
+	const m = TIMESTAMP_COMPACT_RE.exec(name) ?? TIMESTAMP_DASHED_RE.exec(name);
+	if (!m) {
+		return null;
+	}
+	const [, year, month, day, hour, min, sec] = m;
+	const date = new Date(+year, +month - 1, +day, +hour, +min, +sec);
+	// `undefined` locale → JS runtime uses the OS/system locale automatically.
+	const label = date.toLocaleString(undefined, {
+		year: 'numeric',
+		month: 'short',
+		day: 'numeric',
+		hour: '2-digit',
+		minute: '2-digit',
+		second: '2-digit',
+		hour12: false,
+	});
+	return { label, description: name };
+}


### PR DESCRIPTION
- Add 'Clear all' toolbar button to Logs and Screenshots views (with confirmation)
- Add per-item Delete (inline trash icon + right-click context menu, with confirmation)
- Add 'Reveal in File Explorer' toolbar button and per-item context menu entry using VS Code built-in revealFileInOS (works cross-platform)
- Sort top-level items newest-first by mtime in both views
- Display human-readable date/time labels for timestamp-named folders (YYYYMMDDTHHmmss and YYYY-MM-DD_HH-mm-ss); raw name kept as secondary description text; respects OS locale
- Expose resolveLogPath() and resolveScreenshotsPath() as public methods
- Export LogsResourcesItem and ScreenshotsResourcesItem for use in command handlers
- Add contextValue (logFolder/logFile) to LogsResourcesItem to enable context menus
- Add formatLabel.ts utility for timestamp parsing
- Enable Collapse All on Screenshots view
- Update docs/ExtesterRunner.md and features.txt

Closes #2013, #1998

Before submitting your PR, please review the following checklist:

- [ ] **CONSIDER** adding a new test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure tests pass.
- [ ] **DO** make sure any public APIs changes are documented.
- [ ] **DO** make sure not to introduce any compiler warnings.

Before merging the PR:

- [ ] **CHECK** continuous integration of `main` branch is green.
- [ ] **CHECK** pull request check job is green.
- [ ] **CHECK** all pull request questions/requests are resolved.
- [ ] **WAIT** till PR is approved by at least 1 committer.
