### PR TITLE
fix: avoid VS Code startup race when opening resources (#2454)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7500,9 +7500,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",

--- a/packages/extester/src/browser.ts
+++ b/packages/extester/src/browser.ts
@@ -40,7 +40,6 @@ export class VSBrowser {
 	private readonly locale: string;
 	private static _instance: VSBrowser;
 	private readonly _startTimestamp: string;
-	private _sessionStartTime: number = 0;
 
 	private formatTimestamp(date: Date): string {
 		const pad = (num: number) => num.toString().padStart(2, '0');
@@ -191,7 +190,6 @@ export class VSBrowser {
 			.setChromeOptions(options)
 			.build();
 		VSBrowser._instance = this;
-		this._sessionStartTime = Date.now();
 
 		initPageObjects(this.codeVersion, VSBrowser.baseVersion, getLocatorsPath(), this._driver, VSBrowser.browserName, this.customPageObjects?.locatorsPath);
 		return this;
@@ -330,21 +328,6 @@ export class VSBrowser {
 
 		if (paths.length === 0) {
 			return;
-		}
-
-		// CodeUtil.open spawns a second-instance CLI call; if it lands while
-		// VS Code is still starting up, VS Code >= 1.123.0 duplicates every
-		// 256 KiB chunk of every webview resource in the window and the webview
-		// service worker caches the corrupted responses, permanently poisoning
-		// the profile (microsoft/vscode#330243, #2454). The workbench element
-		// appears while that race window is still open, so early calls also wait
-		// for the instance to settle. Calls made later than the settle window pay
-		// no extra delay.
-		const settleMs = Number(process.env.EXTESTER_OPEN_RESOURCE_SETTLE_MS ?? 10_000);
-		const sinceSessionStart = Date.now() - this._sessionStartTime;
-		if (sinceSessionStart < settleMs) {
-			await this.waitForWorkbench();
-			await new Promise((resolve) => setTimeout(resolve, settleMs - sinceSessionStart));
 		}
 
 		const code = new CodeUtil(this.storagePath, this.releaseType, this.extensionsFolder);

--- a/packages/extester/src/browser.ts
+++ b/packages/extester/src/browser.ts
@@ -16,6 +16,7 @@
  */
 
 import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import * as fs from 'fs-extra';
 import { satisfies } from 'compare-versions';
 import { WebDriver, Builder, until, initPageObjects, logging, By, Browser } from '@redhat-developer/page-objects';
@@ -39,6 +40,7 @@ export class VSBrowser {
 	private readonly locale: string;
 	private static _instance: VSBrowser;
 	private readonly _startTimestamp: string;
+	private _sessionStartTime: number = 0;
 
 	private formatTimestamp(date: Date): string {
 		const pad = (num: number) => num.toString().padStart(2, '0');
@@ -70,7 +72,7 @@ export class VSBrowser {
 	 * Starts the vscode browser from a given path
 	 * @param codePath path to code binary
 	 */
-	async start(codePath: string): Promise<VSBrowser> {
+	async start(codePath: string, resources: string[] = []): Promise<VSBrowser> {
 		const settingsDir = path.join(this.storagePath, 'settings');
 		const userSettings = path.join(settingsDir, 'User');
 		const languagePacksPath = path.join(settingsDir, 'languagepacks.json');
@@ -157,6 +159,14 @@ export class VSBrowser {
 			args.push(`--extensionDevelopmentPath=${process.env.EXTENSION_DEV_PATH}`);
 		}
 
+		// Open initial resources with the launch itself instead of a post-launch
+		// second-instance CLI call: when such a call lands while VS Code is still
+		// starting up, VS Code >= 1.123.0 corrupts webview resource streaming for
+		// the whole window (microsoft/vscode#330243, #2454).
+		for (const resource of resources) {
+			args.push(VSBrowser.resourceToLaunchArg(resource));
+		}
+
 		const extraArgs = ['--skip-welcome', '--skip-sessions-welcome', '--skip-release-notes'];
 		let options = new Options().setChromeBinaryPath(codePath).addArguments(...args, ...extraArgs) as any;
 		options['options_'].windowTypes = ['webview'];
@@ -181,9 +191,21 @@ export class VSBrowser {
 			.setChromeOptions(options)
 			.build();
 		VSBrowser._instance = this;
+		this._sessionStartTime = Date.now();
 
 		initPageObjects(this.codeVersion, VSBrowser.baseVersion, getLocatorsPath(), this._driver, VSBrowser.browserName, this.customPageObjects?.locatorsPath);
 		return this;
+	}
+
+	/**
+	 * Convert a filesystem path into the VS Code CLI argument that opens it with
+	 * the initial launch: `--folder-uri` for directories, `--file-uri` for files.
+	 * @param resource path to a file or folder
+	 * @returns the launch argument string
+	 */
+	static resourceToLaunchArg(resource: string): string {
+		const isDirectory = fs.existsSync(resource) && fs.statSync(resource).isDirectory();
+		return `${isDirectory ? '--folder-uri' : '--file-uri'}=${pathToFileURL(path.resolve(resource)).href}`;
 	}
 
 	/**
@@ -308,6 +330,21 @@ export class VSBrowser {
 
 		if (paths.length === 0) {
 			return;
+		}
+
+		// CodeUtil.open spawns a second-instance CLI call; if it lands while
+		// VS Code is still starting up, VS Code >= 1.123.0 duplicates every
+		// 256 KiB chunk of every webview resource in the window and the webview
+		// service worker caches the corrupted responses, permanently poisoning
+		// the profile (microsoft/vscode#330243, #2454). The workbench element
+		// appears while that race window is still open, so early calls also wait
+		// for the instance to settle. Calls made later than the settle window pay
+		// no extra delay.
+		const settleMs = Number(process.env.EXTESTER_OPEN_RESOURCE_SETTLE_MS ?? 10_000);
+		const sinceSessionStart = Date.now() - this._sessionStartTime;
+		if (sinceSessionStart < settleMs) {
+			await this.waitForWorkbench();
+			await new Promise((resolve) => setTimeout(resolve, settleMs - sinceSessionStart));
 		}
 
 		const code = new CodeUtil(this.storagePath, this.releaseType, this.extensionsFolder);

--- a/packages/extester/src/suite/runner.ts
+++ b/packages/extester/src/suite/runner.ts
@@ -24,6 +24,7 @@ import * as path from 'node:path';
 import * as yaml from 'js-yaml';
 import sanitize from 'sanitize-filename';
 import { logging } from 'selenium-webdriver';
+import * as os from 'os';
 import { Coverage } from '../util/coverage';
 
 /**
@@ -38,6 +39,7 @@ export class VSRunner {
 	private readonly releaseType: ReleaseQuality;
 	private readonly customPageObjects?: CustomPageObjectsOptions;
 	private readonly locale: string | undefined;
+	private tmpLink = path.join(os.tmpdir(), 'extest-code');
 
 	constructor(
 		bin: string,
@@ -101,8 +103,11 @@ export class VSRunner {
 				}
 
 				const start = Date.now();
-				await browser.start(self.chromeBin);
-				await browser.openResources(...resources);
+				const binPath = process.platform === 'darwin' ? await self.createShortcut(code.getCodeFolder(), self.tmpLink) : self.chromeBin;
+				// resources are passed to the launch itself: opening them with a
+				// second-instance CLI call during startup triggers webview resource
+				// corruption on VS Code >= 1.123.0 (microsoft/vscode#330243, #2454)
+				await browser.start(binPath, resources);
 				await browser.waitForWorkbench();
 				console.log(`Browser ready in ${Date.now() - start} ms`);
 				console.log('Launching tests...');
@@ -111,6 +116,15 @@ export class VSRunner {
 			this.mocha.suite.afterAll(async function () {
 				this.timeout(180000);
 				await browser.quit();
+				if (process.platform === 'darwin') {
+					if (await fs.pathExists(self.tmpLink)) {
+						try {
+							fs.unlinkSync(self.tmpLink);
+						} catch (err) {
+							console.log(err);
+						}
+					}
+				}
 				if (code.coverageEnabled) {
 					await coverage?.write();
 				}
@@ -125,6 +139,28 @@ export class VSRunner {
 				resolve(process.exitCode);
 			});
 		});
+	}
+
+	private async createShortcut(src: string, dest: string): Promise<string> {
+		try {
+			await fs.ensureSymlink(src, dest, 'dir');
+		} catch (err) {
+			return this.chromeBin;
+		}
+
+		const dir = path.parse(src);
+		const segments = this.chromeBin.split(path.sep);
+		const newSegments = dest.split(path.sep);
+
+		let found = false;
+		for (const segment of segments) {
+			if (!found) {
+				found = segment === dir.base;
+			} else {
+				newSegments.push(segment);
+			}
+		}
+		return path.join(dir.root, ...newSegments);
 	}
 
 	private loadConfig(config?: string): Mocha.MochaOptions {

--- a/packages/extester/src/suite/runner.ts
+++ b/packages/extester/src/suite/runner.ts
@@ -24,7 +24,7 @@ import * as path from 'node:path';
 import * as yaml from 'js-yaml';
 import sanitize from 'sanitize-filename';
 import { logging } from 'selenium-webdriver';
-import * as os from 'os';
+import * as os from 'node:os';
 import { Coverage } from '../util/coverage';
 
 /**
@@ -39,7 +39,7 @@ export class VSRunner {
 	private readonly releaseType: ReleaseQuality;
 	private readonly customPageObjects?: CustomPageObjectsOptions;
 	private readonly locale: string | undefined;
-	private tmpLink = path.join(os.tmpdir(), 'extest-code');
+	private readonly tmpLink = path.join(os.tmpdir(), 'extest-code');
 
 	constructor(
 		bin: string,

--- a/tests/test-project/src/test/resourceLaunchArg.test.ts
+++ b/tests/test-project/src/test/resourceLaunchArg.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License", destination); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as path from 'path';
+import { pathToFileURL } from 'url';
+import { expect } from 'chai';
+import { VSBrowser } from 'vscode-extension-tester';
+
+// Resources passed to `extest run-tests --open_resource` are opened with the
+// initial VS Code launch (--folder-uri / --file-uri) instead of a post-launch
+// second-instance CLI call, which triggers webview resource corruption on
+// VS Code >= 1.123.0 (microsoft/vscode#330243, issue #2454).
+describe('VSBrowser.resourceToLaunchArg', () => {
+	const resources = path.resolve(__dirname, '..', '..', 'resources');
+
+	it('maps a directory to --folder-uri', () => {
+		const arg = VSBrowser.resourceToLaunchArg(path.join(resources, 'test-folder'));
+		expect(arg).to.match(/^--folder-uri=file:\/\//);
+		expect(arg).to.have.string('test-folder');
+	});
+
+	it('maps a file to --file-uri', () => {
+		const arg = VSBrowser.resourceToLaunchArg(path.join(resources, 'test-file.ts'));
+		expect(arg).to.match(/^--file-uri=file:\/\//);
+		expect(arg).to.have.string('test-file.ts');
+	});
+
+	it('percent-encodes special characters so the URI round-trips', () => {
+		const target = path.join(resources, 'folder with speci@l chars');
+		const arg = VSBrowser.resourceToLaunchArg(target);
+		expect(arg).to.have.string('folder%20with%20speci@l%20chars');
+		expect(arg.split('=').slice(1).join('=')).to.equal(pathToFileURL(path.resolve(target)).href);
+	});
+
+	it('resolves relative paths against the working directory', () => {
+		const arg = VSBrowser.resourceToLaunchArg('.');
+		expect(arg).to.equal(`--folder-uri=${pathToFileURL(path.resolve('.')).href}`);
+	});
+});


### PR DESCRIPTION
Fixes #2454.

## Problem

`--open_resource` opens the given resources through a **second-instance CLI call** (`CodeUtil.open`) right after the browser session starts. When that call lands while VS Code is still starting up, VS Code ≥ 1.123.0 hits microsoft/vscode#330243: every 256 KiB chunk of every webview resource in the window is delivered twice, so webview bundles arrive at up to exactly 2× their size, fail to parse, and render blank. Worse, the webview service worker caches the corrupted responses, so a single raced boot permanently poisons the `test-resources/settings` profile — retried CI jobs then fail deterministically. Because it is a race, the failures look intermittent and platform-specific (fast boots escape, slow CI runners corrupt).

Self-contained reproduction of the underlying VS Code bug (no ExTester involved): https://github.com/lordrip/vscode-webview-corruption-repro

## Fix

Two complementary changes:

1. **Resources passed to `extest run-tests --open_resource` are now opened with the initial launch** — `VSBrowser.start` accepts the resources and turns each into a `--folder-uri=` (directories) or `--file-uri=` (files) launch argument via the new `VSBrowser.resourceToLaunchArg` helper. No second instance, no race. `pathToFileURL` handles paths with spaces/special characters.
2. **Runtime `VSBrowser.openResources` calls are guarded**: calls made within the first 10 s of a session (configurable via `EXTESTER_OPEN_RESOURCE_SETTLE_MS`) wait for the workbench and let the instance settle before the CLI open. Calls made later — the normal in-test usage — pay no extra delay.

Tests: `tests/test-project/src/test/resourceLaunchArg.test.ts` covers the directory/file mapping, percent-encoding round-trip, and relative-path resolution. The existing e2e suite exercises the launch-args path directly since it runs with `-r .`.

## Validation

- Measured with a minimal custom-editor extension reporting `fetch(scriptSrc).arrayBuffer().byteLength` from inside its webview, VS Code 1.132.0, fresh profile: unpatched `--open_resource` runs corrupt (ratio 1.98–2.0); with the settle guard the same scenario is clean 2/2; opening the folder via launch arguments never triggered the corruption in any measurement.
- The settle-guard workaround, shipped as a Yarn patch, took KaotoIO/vscode-kaoto's webview integration-test matrix on VS Code 1.132.0 from **5/7 jobs failing to 7/7 green** (KaotoIO/vscode-kaoto#1476, validation in KaotoIO/vscode-kaoto#1475).

Full investigation write-up: KaotoIO/vscode-kaoto#1468.

---

The investigation, reproduction and this fix were done with the help of [Claude Code](https://claude.com/claude-code); a human (me) reviewed and is accountable for the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtvAiEuFSkrYXehmdRdbHo