### PR TITLE
ci: split main CI pipeline into per-test-group parallel jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,15 +43,83 @@ jobs:
       - name: 🔍 Run Unit Tests
         run: npm run test:unit
 
-  main:
-    name: ${{ matrix.version }}
-    strategy:
-      fail-fast: false
-      matrix:
-        version: [min, max]
-    uses: ./.github/workflows/template-main.yaml
+  group_01_general:
+    name: 🧪 01_general
+    uses: ./.github/workflows/template-suite.yaml
     with:
-      version: ${{ matrix.version }}
+      test_group: 01_general
+
+  group_activityBar:
+    name: 🧪 activityBar
+    uses: ./.github/workflows/template-suite.yaml
+    with:
+      test_group: activityBar
+
+  group_bottomBar:
+    name: 🧪 bottomBar
+    uses: ./.github/workflows/template-suite.yaml
+    with:
+      test_group: bottomBar
+
+  group_cli:
+    name: 🧪 cli
+    uses: ./.github/workflows/template-suite.yaml
+    with:
+      test_group: cli
+
+  group_debug:
+    name: 🧪 debug
+    uses: ./.github/workflows/template-suite.yaml
+    with:
+      test_group: debug
+
+  group_dialog:
+    name: 🧪 dialog
+    uses: ./.github/workflows/template-suite.yaml
+    with:
+      test_group: dialog
+
+  group_editor:
+    name: 🧪 editor
+    uses: ./.github/workflows/template-suite.yaml
+    with:
+      test_group: editor
+
+  group_menu:
+    name: 🧪 menu
+    uses: ./.github/workflows/template-suite.yaml
+    with:
+      test_group: menu
+
+  group_statusBar:
+    name: 🧪 statusBar
+    uses: ./.github/workflows/template-suite.yaml
+    with:
+      test_group: statusBar
+
+  group_system:
+    name: 🧪 system
+    uses: ./.github/workflows/template-suite.yaml
+    with:
+      test_group: system
+
+  group_webview:
+    name: 🧪 webview
+    uses: ./.github/workflows/template-suite.yaml
+    with:
+      test_group: webview
+
+  group_workbench:
+    name: 🧪 workbench
+    uses: ./.github/workflows/template-suite.yaml
+    with:
+      test_group: workbench
+
+  group_xsideBar:
+    name: 🧪 xsideBar
+    uses: ./.github/workflows/template-suite.yaml
+    with:
+      test_group: xsideBar
 
   runner:
     uses: ./.github/workflows/template-runner.yaml
@@ -62,20 +130,77 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     name: 🚦 Status Check
-    needs: [main, runner, unit]
+    needs:
+      - unit
+      - runner
+      - group_01_general
+      - group_activityBar
+      - group_bottomBar
+      - group_cli
+      - group_debug
+      - group_dialog
+      - group_editor
+      - group_menu
+      - group_statusBar
+      - group_system
+      - group_webview
+      - group_workbench
+      - group_xsideBar
     steps:
       - name: ℹ️ Test Matrix Result
         run: |
-          echo Unit Test result = ${{ needs.unit.result }}
-          echo Main Test result = ${{ needs.main.result }}
-          echo Runner Test result = ${{ needs.runner.result }}
+          echo Unit Test result              = ${{ needs.unit.result }}
+          echo Runner Test result            = ${{ needs.runner.result }}
+          echo 01_general Test result        = ${{ needs.group_01_general.result }}
+          echo activityBar Test result       = ${{ needs.group_activityBar.result }}
+          echo bottomBar Test result         = ${{ needs.group_bottomBar.result }}
+          echo cli Test result               = ${{ needs.group_cli.result }}
+          echo debug Test result             = ${{ needs.group_debug.result }}
+          echo dialog Test result            = ${{ needs.group_dialog.result }}
+          echo editor Test result            = ${{ needs.group_editor.result }}
+          echo menu Test result              = ${{ needs.group_menu.result }}
+          echo statusBar Test result         = ${{ needs.group_statusBar.result }}
+          echo system Test result            = ${{ needs.group_system.result }}
+          echo webview Test result           = ${{ needs.group_webview.result }}
+          echo workbench Test result         = ${{ needs.group_workbench.result }}
+          echo xsideBar Test result          = ${{ needs.group_xsideBar.result }}
       - name: ✅ Status Check - success
-        if: ${{ needs.main.result == 'success' && needs.runner.result == 'success' && needs.unit.result == 'success' }}
+        if: |
+          needs.unit.result == 'success' &&
+          needs.runner.result == 'success' &&
+          needs.group_01_general.result == 'success' &&
+          needs.group_activityBar.result == 'success' &&
+          needs.group_bottomBar.result == 'success' &&
+          needs.group_cli.result == 'success' &&
+          needs.group_debug.result == 'success' &&
+          needs.group_dialog.result == 'success' &&
+          needs.group_editor.result == 'success' &&
+          needs.group_menu.result == 'success' &&
+          needs.group_statusBar.result == 'success' &&
+          needs.group_system.result == 'success' &&
+          needs.group_webview.result == 'success' &&
+          needs.group_workbench.result == 'success' &&
+          needs.group_xsideBar.result == 'success'
         run: |
           echo "All tests successfully completed!"
           exit 0
       - name: ❌ Status Check - failure
-        if: ${{ needs.main.result != 'success' || needs.runner.result != 'success' || needs.unit.result != 'success' }}
+        if: |
+          needs.unit.result != 'success' ||
+          needs.runner.result != 'success' ||
+          needs.group_01_general.result != 'success' ||
+          needs.group_activityBar.result != 'success' ||
+          needs.group_bottomBar.result != 'success' ||
+          needs.group_cli.result != 'success' ||
+          needs.group_debug.result != 'success' ||
+          needs.group_dialog.result != 'success' ||
+          needs.group_editor.result != 'success' ||
+          needs.group_menu.result != 'success' ||
+          needs.group_statusBar.result != 'success' ||
+          needs.group_system.result != 'success' ||
+          needs.group_webview.result != 'success' ||
+          needs.group_workbench.result != 'success' ||
+          needs.group_xsideBar.result != 'success'
         run: |
           echo "Status Check failed!"
           exit 1

--- a/.github/workflows/template-runner.yaml
+++ b/.github/workflows/template-runner.yaml
@@ -32,6 +32,10 @@ jobs:
       - name: 👷🏻 Checkout Repository
         uses: actions/checkout@v7
 
+      - name: ⚙️ Set TEST_RESOURCES path
+        run: echo "TEST_RESOURCES=${{ runner.temp }}/test-resources" >> $GITHUB_ENV
+        shell: bash
+
       - name: ⚙️ Setup NodeJS
         uses: actions/setup-node@v7
         with:
@@ -45,7 +49,7 @@ jobs:
         run: npm run build
 
       - name: ✨ Code Formatter - Prettier
-        run: npx prettier . --check
+        run: ./node_modules/.bin/prettier . --check
 
       - name: 🔧 Install - ExTester Runner
         run: npm install --workspace=extester-runner

--- a/.github/workflows/template-suite.yaml
+++ b/.github/workflows/template-suite.yaml
@@ -1,9 +1,9 @@
-name: 📄 Main CI - template
+name: 📄 Suite CI - template
 
 on:
   workflow_call:
     inputs:
-      version:
+      test_group:
         required: true
         type: string
       nodejs:
@@ -17,16 +17,34 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.os }}
+    name: ${{ matrix.label }}
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: ubuntu-min
+            version: min
+          - os: ubuntu-latest
+            label: ubuntu-max
+            version: max
+          - os: macos-latest
+            label: macos-min
+            version: min
+          - os: macos-latest
+            label: macos-max
+            version: max
+          - os: windows-latest
+            label: windows-min
+            version: min
+          - os: windows-latest
+            label: windows-max
+            version: max
 
     env:
       CODE_TYPE: ${{ inputs.code_type }}
-      CODE_VERSION: ${{ inputs.version }}
+      CODE_VERSION: ${{ matrix.version }}
 
     steps:
       - name: 👷🏻 Checkout Repository
@@ -43,7 +61,7 @@ jobs:
           cache: npm
 
       - name: 🔧 Install
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: 🔧 Build
         run: npm run build
@@ -54,51 +72,23 @@ jobs:
       - name: 🔧 Install - Test Project
         run: npm install --workspace=extester-test
 
-      - name: 🔍 Run Tests (macOS)
-        uses: nick-fields/retry@v4
-        if: ${{ startsWith(matrix.os, 'mac') }}
-        with:
-          timeout_minutes: 20
-          retry_wait_seconds: 60
-          max_attempts: 3
-          command: npm test
-
-      - name: 🔍 Run Tests (windows)
-        uses: nick-fields/retry@v4
-        if: ${{ startsWith(matrix.os, 'win') }}
-        with:
-          timeout_minutes: 20
-          retry_wait_seconds: 30
-          max_attempts: 3
-          command: npm test
+      - name: 🔍 Run Tests (macOS, windows)
+        if: ${{ !startsWith(matrix.os, 'ubuntu') }}
+        run: npm run test:${{ inputs.test_group }} --workspace=extester-test
 
       - name: ⚙️ Allow unprivileged user namespace (ubuntu)
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
       - name: 🔍 Run Tests (linux)
-        uses: nick-fields/retry@v4
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
-        with:
-          timeout_minutes: 20
-          retry_wait_seconds: 30
-          max_attempts: 3
-          command: xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npm test
+        run: xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npm run test:${{ inputs.test_group }} --workspace=extester-test
 
-      - name: 💾 Upload Screenshots
+      - name: 💾 Upload Screenshots and ChromeDriver logs
         uses: actions/upload-artifact@v7
-        if: failure() && inputs.nodejs != 'lts/*'
+        if: failure()
         with:
-          name: screenshots-${{ matrix.os }}-${{ inputs.version }}-node_${{ inputs.nodejs }}
-          path: |
-            ${{ runner.temp }}/test-resources/screenshots/**/*.png
-            ${{ runner.temp }}/test-resources/chromedriver.log
-
-      - name: 💾 Upload Screenshots
-        uses: actions/upload-artifact@v7
-        if: failure() && inputs.nodejs == 'lts/*'
-        with:
-          name: screenshots-${{ matrix.os }}-${{ inputs.version }}-node_lts
+          name: screenshots-and-logs-${{ matrix.label }}-${{ inputs.test_group }}
           path: |
             ${{ runner.temp }}/test-resources/screenshots/**/*.png
             ${{ runner.temp }}/test-resources/chromedriver.log

--- a/package.json
+++ b/package.json
@@ -19,7 +19,20 @@
     "test:build": "npm run build:changed && npm install --workspace=extester-test && npm test",
     "test:runner:unit": "npm test --workspace=extester-runner",
     "test:runner:ui": "npm run ui-test --workspace=extester-runner",
-    "test:unit": "npm run test:unit --workspace=vscode-extension-tester"
+    "test:unit": "npm run test:unit --workspace=vscode-extension-tester",
+    "test:01_general": "npm run test:01_general --workspace=extester-test",
+    "test:activityBar": "npm run test:activityBar --workspace=extester-test",
+    "test:bottomBar": "npm run test:bottomBar --workspace=extester-test",
+    "test:cli": "npm run test:cli --workspace=extester-test",
+    "test:debug": "npm run test:debug --workspace=extester-test",
+    "test:dialog": "npm run test:dialog --workspace=extester-test",
+    "test:editor": "npm run test:editor --workspace=extester-test",
+    "test:menu": "npm run test:menu --workspace=extester-test",
+    "test:statusBar": "npm run test:statusBar --workspace=extester-test",
+    "test:system": "npm run test:system --workspace=extester-test",
+    "test:webview": "npm run test:webview --workspace=extester-test",
+    "test:workbench": "npm run test:workbench --workspace=extester-test",
+    "test:xsideBar": "npm run test:xsideBar --workspace=extester-test"
   },
   "workspaces": [
     "packages/*",

--- a/packages/extester/src/browser.ts
+++ b/packages/extester/src/browser.ts
@@ -19,7 +19,7 @@ import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import * as fs from 'fs-extra';
 import { satisfies } from 'compare-versions';
-import { WebDriver, Builder, until, initPageObjects, logging, By, Browser } from '@redhat-developer/page-objects';
+import { WebDriver, Builder, initPageObjects, logging, By, Browser, EditorView, Workbench } from '@redhat-developer/page-objects';
 import { Options, ServiceBuilder } from 'selenium-webdriver/chrome';
 import { getLocatorsPath } from '@redhat-developer/locators';
 import { CodeUtil, CustomPageObjectsOptions, ReleaseQuality } from './util/codeUtil';
@@ -40,6 +40,7 @@ export class VSBrowser {
 	private readonly locale: string;
 	private static _instance: VSBrowser;
 	private readonly _startTimestamp: string;
+	private static _signalHandlersRegistered = false;
 
 	private formatTimestamp(date: Date): string {
 		const pad = (num: number) => num.toString().padStart(2, '0');
@@ -104,6 +105,14 @@ export class VSBrowser {
 		}
 
 		let defaultSettings = {
+			// Never let the tested VS Code instance update itself mid-run: on macOS
+			// the background updater replaces application files while tests execute,
+			// which manifests as "Your Code installation appears to be corrupt" and a
+			// dead extension host ("version mismatch") partway through a session.
+			'update.mode': 'none',
+			'update.showReleaseNotes': false,
+			'extensions.autoUpdate': false,
+			'extensions.autoCheckUpdates': false,
 			'workbench.editor.enablePreview': false,
 			'workbench.startupEditor': 'none',
 			'window.titleBarStyle': 'custom',
@@ -189,10 +198,51 @@ export class VSBrowser {
 			.forBrowser(Browser.CHROME)
 			.setChromeOptions(options)
 			.build();
+
+		await this._driver.manage().setTimeouts({
+			implicit: 0,
+			pageLoad: 60_000,
+			script: 30_000,
+		});
+
 		VSBrowser._instance = this;
 
 		initPageObjects(this.codeVersion, VSBrowser.baseVersion, getLocatorsPath(), this._driver, VSBrowser.browserName, this.customPageObjects?.locatorsPath);
+		VSBrowser.registerSignalHandlers();
 		return this;
+	}
+
+	/**
+	 * Register process signal handlers to ensure the WebDriver session is
+	 * terminated when the process exits unexpectedly (Ctrl+C, kill, crash).
+	 * Prevents orphaned ChromeDriver and VS Code processes on CI.
+	 */
+	private static registerSignalHandlers(): void {
+		if (VSBrowser._signalHandlersRegistered) {
+			return;
+		}
+		VSBrowser._signalHandlersRegistered = true;
+
+		const emergencyShutdown = async (reason: string, exitCode: number) => {
+			console.error(`Emergency browser shutdown triggered by ${reason}`);
+			try {
+				if (VSBrowser._instance?._driver) {
+					// Bound the quit call — if ChromeDriver is unresponsive (likely when the
+					// process is being killed), waiting on it forever would defeat the purpose
+					// of this handler and stall the CI runner's shutdown.
+					await Promise.race([VSBrowser._instance._driver.quit(), new Promise((res) => setTimeout(res, 5_000))]);
+				}
+			} catch {
+				// best-effort; process is already dying
+			}
+			process.exit(exitCode);
+		};
+
+		// NOTE: deliberately no 'uncaughtException' handler here — Mocha installs its own
+		// to fail the current test and continue the run; exiting the process from a second
+		// handler would abort the whole suite on any stray async error.
+		process.on('SIGINT', () => void emergencyShutdown('SIGINT', 130));
+		process.on('SIGTERM', () => void emergencyShutdown('SIGTERM', 143));
 	}
 
 	/**
@@ -252,16 +302,51 @@ export class VSBrowser {
 	 * });
 	 */
 	async waitForWorkbench(timeout: number = 30_000, waitForFn?: () => void | Promise<any>): Promise<void> {
-		// Workaround/patch for https://github.com/redhat-developer/vscode-extension-tester/issues/466
-		try {
-			await this._driver.wait(until.elementLocated(By.className('monaco-workbench')), timeout, `Workbench was not loaded properly after ${timeout} ms.`);
-		} catch (err) {
-			if ((err as Error).name === 'WebDriverError') {
-				await new Promise((res) => setTimeout(res, 3000));
-			} else {
-				throw err;
-			}
-		}
+		// Errors that indicate the workbench is not (or no longer) present rather than a
+		// broken session: the window may be mid-reload (e.g. a folder was just opened,
+		// which reloads the whole workbench), so keep polling instead of failing.
+		const transientErrors = new Set(['NoSuchElementError', 'StaleElementReferenceError', 'WebDriverError', 'NoSuchWindowError']);
+		// Require the workbench to stay present across two checks ~500ms apart:
+		// right before a window reload the OLD document is still visible for an
+		// instant, and returning at that moment hands callers elements that die
+		// immediately after.
+		let presentSince = 0;
+		await this._driver.wait(
+			async () => {
+				try {
+					const workbench = await this._driver.findElements(By.className('monaco-workbench'));
+					const present = workbench.length > 0 && (await workbench[0].isDisplayed());
+					if (!present) {
+						presentSince = 0;
+						return false;
+					}
+					if (presentSince === 0) {
+						presentSince = Date.now();
+						return false;
+					}
+					return Date.now() - presentSince >= 500;
+				} catch (err) {
+					presentSince = 0;
+					const name = (err as Error).name;
+					if (name === 'NoSuchWindowError') {
+						// The window handle died (e.g. replaced during a reload) — re-attach
+						// to the first available window and keep polling.
+						const handles = await this._driver.getAllWindowHandles().catch(() => [] as string[]);
+						if (handles.length > 0) {
+							await this._driver.switchTo().window(handles[0]);
+						}
+						return false;
+					}
+					if (transientErrors.has(name)) {
+						return false;
+					}
+					throw err;
+				}
+			},
+			timeout,
+			`Workbench was not loaded properly after ${timeout} ms.`,
+		);
+
 		if (waitForFn) {
 			await waitForFn();
 		}
@@ -271,16 +356,24 @@ export class VSBrowser {
 	 * Terminates the webdriver/browser
 	 */
 	async quit(): Promise<void> {
-		const entries = await this._driver.manage().logs().get(logging.Type.DRIVER);
-		const logFile = path.join(this.storagePath, 'test.log');
-		const stream = fs.createWriteStream(logFile, { flags: 'w' });
-		for (const entry of entries) {
-			stream.write(`[${new Date(entry.timestamp).toLocaleTimeString()}][${entry.level.name}] ${entry.message}`);
+		try {
+			const entries = await this._driver.manage().logs().get(logging.Type.DRIVER);
+			const logFile = path.join(this.storagePath, 'test.log');
+			const logStream = fs.createWriteStream(logFile, { flags: 'w' });
+			for (const entry of entries) {
+				logStream.write(`[${new Date(entry.timestamp).toLocaleTimeString()}][${entry.level.name}] ${entry.message}`);
+			}
+			logStream.end();
+		} catch (err) {
+			console.error('Failed to collect driver logs before shutdown:', err);
+		} finally {
+			console.log('Shutting down the browser');
+			try {
+				await this._driver.quit();
+			} catch (quitErr) {
+				console.error('Error while quitting the driver:', quitErr);
+			}
 		}
-		stream.end();
-
-		console.log('Shutting down the browser');
-		await this._driver.quit();
 	}
 
 	/**
@@ -333,5 +426,54 @@ export class VSBrowser {
 		const code = new CodeUtil(this.storagePath, this.releaseType, this.extensionsFolder);
 		code.open(...paths);
 		await this.waitForWorkbench(undefined, waitForFn);
+
+		// The CLI open request can occasionally get lost by the running VS Code instance
+		// (observed on macOS after a workspace switch reloaded the window). Verify that
+		// each file resource actually shows up as an editor tab and retry the open once
+		// before giving up, so callers fail fast with a clear error instead of timing
+		// out later on a missing editor.
+		const files = paths.filter((p) => fs.existsSync(p) && fs.statSync(p).isFile());
+		if (files.length > 0 && !(await this.filesOpenedInEditor(files, 15_000))) {
+			console.warn(`Opened resources did not appear in the editor, retrying: ${files.join(', ')}`);
+			code.open(...paths);
+			await this.waitForWorkbench();
+			if (!(await this.filesOpenedInEditor(files, 10_000))) {
+				// The running instance can drop CLI open requests entirely mid-session
+				// (observed repeatedly on macOS). Fall back to opening each file through
+				// the workbench quick open box, which does not depend on the CLI channel.
+				console.warn(`CLI open request was dropped, opening file(s) via quick open: ${files.join(', ')}`);
+				for (const file of files) {
+					const input = await new Workbench().openCommandPrompt();
+					await input.setText(file);
+					await input.confirm();
+				}
+				if (!(await this.filesOpenedInEditor(files, 10_000))) {
+					throw new Error(`Failed to open resource(s) in the editor: ${files.join(', ')}`);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Best-effort check that every given file is open as an editor tab.
+	 * Resolves to true once all file basenames are found among the open editor titles
+	 * in any editor group, false if that does not happen within the given timeout.
+	 */
+	private async filesOpenedInEditor(files: string[], timeout: number): Promise<boolean> {
+		const names = files.map((f) => path.basename(f));
+		try {
+			await this._driver.wait(async () => {
+				try {
+					const titles = await new EditorView().getOpenEditorTitles();
+					return names.every((name) => titles.some((title) => title === name || title.startsWith(name)));
+				} catch {
+					// Editor area may not exist yet (empty window) or may be mid-reload
+					return false;
+				}
+			}, timeout);
+			return true;
+		} catch {
+			return false;
+		}
 	}
 }

--- a/packages/extester/src/cli.ts
+++ b/packages/extester/src/cli.ts
@@ -261,6 +261,7 @@ program
 					cleanup: cmd.uninstall_extension || run.cleanup,
 					config: cmd.mocha_config ?? run.mochaConfig,
 					logLevel: cmd.log_level ?? run.logLevel,
+					offline: cmd.offline || run.offline,
 					resources: cmd.open_resource ?? run.resources ?? [],
 					customPageObjects: customPageObjectsPath ? { locatorsPath: customPageObjectsPath } : undefined,
 					locale: cmd.locale ?? run.locale,

--- a/packages/extester/src/extester.ts
+++ b/packages/extester/src/extester.ts
@@ -96,13 +96,10 @@ export class ExTester {
 	} = {}): Promise<void> {
 		let target = vsixFile;
 		if (vsixFile) {
-			try {
-				// Attempt to handle vsixFile as a URL
-				const uri = new URL(vsixFile);
-				target = await this.code.downloadExtension(uri.toString());
+			if (ExTester.isURL(vsixFile)) {
+				target = await this.code.downloadExtension(vsixFile);
 				this.code.installExtension(target);
-			} catch (urlError) {
-				//Convert Windows-style paths to Unix-style for glob
+			} else {
 				const normalizedPattern = vsixFile.replace(/\\/g, '/');
 				const vsixFiles = globSync(normalizedPattern);
 
@@ -111,13 +108,9 @@ export class ExTester {
 				}
 
 				for (const file of vsixFiles) {
-					try {
-						const normalizedPath = path.normalize(file);
-						const target = await this.processVsixFile(normalizedPath);
-						this.code.installExtension(target);
-					} catch (error) {
-						console.error(`Error installing ${file}:`, error);
-					}
+					const normalizedPath = path.normalize(file);
+					const processedTarget = await this.processVsixFile(normalizedPath);
+					this.code.installExtension(processedTarget);
 				}
 			}
 		} else {
@@ -127,6 +120,15 @@ export class ExTester {
 
 		if (installDependencies) {
 			this.code.installDependencies();
+		}
+	}
+
+	private static isURL(value: string): boolean {
+		try {
+			const url = new URL(value);
+			return url.protocol === 'http:' || url.protocol === 'https:';
+		} catch {
+			return false;
 		}
 	}
 
@@ -189,8 +191,9 @@ export class ExTester {
 			await this.downloadChromeDriver(vscodeParsedVersion, noCache);
 		} else {
 			console.log('Attempting Setup in offline mode');
-			const expectedChromeVersion = this.code.checkOfflineRequirements().split('.')[0];
-			const actualChromeVersion = (await this.chrome.checkDriverVersionOffline(vscodeParsedVersion)).split('.')[0];
+			const chromiumVersion = this.code.checkOfflineRequirements();
+			const expectedChromeVersion = chromiumVersion.split('.')[0];
+			const actualChromeVersion = (await this.chrome.checkDriverVersionOffline(chromiumVersion)).split('.')[0];
 			if (expectedChromeVersion !== actualChromeVersion) {
 				console.log(
 					'\x1b[33m%s\x1b[0m',

--- a/packages/extester/src/suite/runner.ts
+++ b/packages/extester/src/suite/runner.ts
@@ -69,7 +69,7 @@ export class VSRunner {
 	 * @return The exit code of the mocha process
 	 */
 	runTests(testFilesPattern: string[], code: CodeUtil, resources: string[], logLevel: logging.Level = logging.Level.INFO): Promise<number> {
-		return new Promise((resolve) => {
+		return new Promise((resolve, reject) => {
 			const self = this;
 			const browser: VSBrowser = new VSBrowser(this.codeVersion, this.releaseType, this.customSettings, logLevel, this.customPageObjects, this.locale);
 			let coverage: Coverage | undefined;
@@ -83,8 +83,11 @@ export class VSRunner {
 			}
 
 			testFiles.forEach((file) => this.mocha.addFile(file));
+
 			this.mocha.suite.afterEach(async function () {
-				if (this.currentTest && this.currentTest.state !== 'passed') {
+				// Screenshot only genuinely failed tests — 'pending' (skipped) tests
+				// would otherwise produce misleading failure screenshots in CI artifacts.
+				if (this.currentTest?.state === 'failed') {
 					try {
 						const filename = sanitize(this.currentTest.fullTitle());
 						await browser.takeScreenshot(filename);
@@ -115,29 +118,49 @@ export class VSRunner {
 
 			this.mocha.suite.afterAll(async function () {
 				this.timeout(180000);
-				await browser.quit();
+
+				try {
+					await browser.quit();
+				} catch (err) {
+					console.error('Error shutting down browser:', err);
+				}
+
 				if (process.platform === 'darwin') {
-					if (await fs.pathExists(self.tmpLink)) {
-						try {
+					try {
+						if (await fs.pathExists(self.tmpLink)) {
 							fs.unlinkSync(self.tmpLink);
-						} catch (err) {
-							console.log(err);
 						}
+					} catch (err) {
+						console.error('Error removing macOS symlink:', err);
 					}
 				}
+
 				if (code.coverageEnabled) {
-					await coverage?.write();
+					try {
+						await coverage?.write();
+					} catch (err) {
+						console.error('Error writing coverage data:', err);
+					}
 				}
-				code.uninstallExtension(self.cleanup);
+
+				try {
+					code.uninstallExtension(self.cleanup);
+				} catch (err) {
+					console.error('Error uninstalling extension:', err);
+				}
 			});
 
-			this.mocha.run((failures) => {
-				process.exitCode = failures ? 1 : 0;
-				if (process.exitCode) {
-					console.log('\x1b[33m%s\x1b[0m', `INFO: Screenshots of failures can be found in: ${browser.getScreenshotsDir()}\n`);
-				}
-				resolve(process.exitCode);
-			});
+			try {
+				this.mocha.run((failures) => {
+					process.exitCode = failures ? 1 : 0;
+					if (process.exitCode) {
+						console.log('\x1b[33m%s\x1b[0m', `INFO: Screenshots of failures can be found in: ${browser.getScreenshotsDir()}\n`);
+					}
+					resolve(process.exitCode);
+				});
+			} catch (err) {
+				reject(err);
+			}
 		});
 	}
 
@@ -166,6 +189,7 @@ export class VSRunner {
 	private loadConfig(config?: string): Mocha.MochaOptions {
 		const defaultFiles = ['.mocharc.js', '.mocharc.json', '.mocharc.yml', '.mocharc.yaml'];
 		let conf: Mocha.MochaOptions = {};
+		const isExplicit = !!config;
 		let file = config;
 		if (!config) {
 			file = path.resolve('.');
@@ -183,16 +207,26 @@ export class VSRunner {
 				try {
 					conf = yaml.load(fs.readFileSync(file, 'utf-8')) as Mocha.MochaOptions;
 				} catch (err) {
-					console.log('Invalid mocha configuration file, will be ignored');
+					if (isExplicit) {
+						throw new Error(`Failed to parse mocha configuration ${file}: ${err}`);
+					}
+					console.log(`Invalid mocha configuration file ${file}, will be ignored:`, err);
 				}
 			} else if (/\.(js|json)$/.test(file)) {
 				try {
 					conf = require(path.resolve(file));
 				} catch (err) {
-					console.log('Invalid mocha configuration file, will be ignored');
+					if (isExplicit) {
+						throw new Error(`Failed to load mocha configuration ${file}: ${err}`);
+					}
+					console.log(`Invalid mocha configuration file ${file}, will be ignored:`, err);
 				}
 			} else {
-				console.log('Unsupported mocha configuration file extension, make sure to use .js, .json, .yml or .yaml file');
+				const msg = `Unsupported mocha configuration file extension: ${file}. Use .js, .json, .yml or .yaml.`;
+				if (isExplicit) {
+					throw new Error(msg);
+				}
+				console.log(msg);
 			}
 		}
 

--- a/packages/extester/src/util/codeUtil.ts
+++ b/packages/extester/src/util/codeUtil.ts
@@ -90,6 +90,7 @@ export class CodeUtil {
 	private readonly extensionsFolder: string | undefined;
 	private readonly coverage: boolean | undefined;
 	private readonly env: NodeJS.ProcessEnv = { ...process.env };
+	private cachedCodeVersion: string | undefined;
 
 	/**
 	 * Create an instance of code handler
@@ -128,8 +129,7 @@ export class CodeUtil {
 	 */
 	async getVSCodeVersions(): Promise<string[]> {
 		const apiUrl = `https://update.code.visualstudio.com/api/releases/${this.releaseType}`;
-		const json = await Download.getText(apiUrl);
-		return json as unknown as string[];
+		return await Download.getJSON<string[]>(apiUrl);
 	}
 
 	/**
@@ -150,6 +150,7 @@ export class CodeUtil {
 
 		console.log(`Downloading VS Code: ${literalVersion} / ${this.releaseType}`);
 		if (!fs.existsSync(this.getExecutablePath()) || this.getExistingCodeVersion() !== literalVersion || noCache) {
+			this.cachedCodeVersion = undefined;
 			fs.mkdirpSync(this.downloadFolder);
 
 			const url = ['https://update.code.visualstudio.com', version, this.downloadPlatform, this.releaseType].join('/');
@@ -176,6 +177,19 @@ export class CodeUtil {
 				console.log(`Downloaded VS Code into ${zipPath}`);
 			}
 
+			// A corrupted archive (truncated download, stale cache entry) produces a broken
+			// VS Code install that fails much later in confusing ways ("installation appears
+			// to be corrupt", extension host not starting). Verify the archive up front and
+			// re-download once before unpacking.
+			if (!this.verifyArchiveIntegrity(zipPath)) {
+				console.warn(`VS Code archive ${fileName} is corrupted, re-downloading...`);
+				await fs.remove(zipPath);
+				await Download.getFile(url, zipPath, true);
+				if (!this.verifyArchiveIntegrity(zipPath)) {
+					throw new Error(`Downloaded VS Code archive is corrupted: ${zipPath}`);
+				}
+			}
+
 			const tempPrefix = path.join(this.downloadFolder, 'vscode-temp-');
 			console.log(`Unpacking VS Code into ${this.downloadFolder}`);
 			const target = await fs.mkdtemp(tempPrefix);
@@ -192,7 +206,23 @@ export class CodeUtil {
 					// Remove macOS quarantine attribute that may be inherited from the downloaded
 					// zip on newer macOS versions (Sequoia / Tahoe), which would prevent
 					// the hardened-runtime app bundle from launching via ChromeDriver.
-					childProcess.execSync(`xattr -r -d com.apple.quarantine "${this.codeFolder}"`, { stdio: 'ignore' });
+					try {
+						childProcess.execSync(`xattr -r -d com.apple.quarantine "${this.codeFolder}"`, { stdio: 'ignore', timeout: 30_000 });
+					} catch {
+						// xattr -d exits non-zero when the attribute is absent. Verify that
+						// quarantine is actually gone; only fail if it persists.
+						try {
+							const attrs = childProcess.execSync(`xattr "${this.codeFolder}"`, { timeout: 10_000 }).toString();
+							if (attrs.includes('com.apple.quarantine')) {
+								throw new Error(`Failed to remove quarantine attribute from ${this.codeFolder}`);
+							}
+						} catch (verifyErr) {
+							if (verifyErr instanceof Error && verifyErr.message.includes('Failed to remove quarantine')) {
+								throw verifyErr;
+							}
+							// xattr listing itself failed — attribute is likely absent
+						}
+					}
 				}
 				console.log('Success!');
 				if (noCache) {
@@ -204,6 +234,28 @@ export class CodeUtil {
 			}
 		} else {
 			console.log('VS Code exists in local cache, skipping download');
+		}
+	}
+
+	/**
+	 * Check that a downloaded VS Code archive is a readable, complete archive.
+	 * Returns true when the archive passes the check or when no suitable
+	 * verification tool is available on the current platform.
+	 */
+	private verifyArchiveIntegrity(archive: string): boolean {
+		if (process.platform === 'win32') {
+			// No archive test tool is guaranteed to exist on Windows — skip verification
+			return true;
+		}
+		try {
+			if (archive.endsWith('.tar.gz')) {
+				childProcess.execSync(`tar -tzf "${archive}"`, { stdio: 'ignore', timeout: 120_000 });
+			} else {
+				childProcess.execSync(`unzip -t -qq "${archive}"`, { stdio: 'ignore', timeout: 120_000 });
+			}
+			return true;
+		} catch {
+			return false;
 		}
 	}
 
@@ -256,10 +308,10 @@ export class CodeUtil {
 			command += ' --pre-release';
 		}
 		if (this.extensionsFolder) {
-			command += ` --extensions-dir=${this.extensionsFolder}`;
+			command += ` --extensions-dir="${this.extensionsFolder}"`;
 		}
 		command += ` --user-data-dir="${path.join(this.downloadFolder, 'settings')}"`;
-		childProcess.execSync(command, { stdio: 'inherit' });
+		childProcess.execSync(command, { stdio: 'inherit', timeout: 120_000 });
 	}
 
 	/**
@@ -269,7 +321,7 @@ export class CodeUtil {
 	open(...paths: string[]): void {
 		const segments = paths.map((f) => `"${f}"`).join(' ');
 		const command = `${this.getCliInitCommand()} -r ${segments} --user-data-dir="${path.join(this.downloadFolder, 'settings')}"`;
-		childProcess.execSync(command);
+		childProcess.execSync(command, { timeout: 30000 });
 	}
 
 	/**
@@ -310,9 +362,9 @@ export class CodeUtil {
 		if (cleanup) {
 			let command = `${this.getCliInitCommand()} --uninstall-extension "${extension}"`;
 			if (this.extensionsFolder) {
-				command += ` --extensions-dir=${this.extensionsFolder}`;
+				command += ` --extensions-dir="${this.extensionsFolder}"`;
 			}
-			childProcess.execSync(command, { stdio: 'inherit' });
+			childProcess.execSync(command, { stdio: 'inherit', timeout: 60_000 });
 		}
 	}
 
@@ -333,16 +385,22 @@ export class CodeUtil {
 		const literalVersion =
 			runOptions.vscodeVersion === undefined || runOptions.vscodeVersion === 'latest' ? this.availableVersions[0] : runOptions.vscodeVersion;
 
-		// add chromedriver to process' path
-		const finalEnv: NodeJS.ProcessEnv = {};
-		Object.assign(finalEnv, process.env);
-		const key = 'PATH';
-		finalEnv[key] = [this.downloadFolder, process.env[key]].join(path.delimiter);
+		// Save the original environment so we can restore it after the test run
+		const savedEnv = { ...process.env };
 
-		process.env = finalEnv;
+		const key = 'PATH';
+		process.env[key] = [this.downloadFolder, process.env[key]].join(path.delimiter);
 		process.env.TEST_RESOURCES = this.downloadFolder;
-		process.env.EXTENSIONS_FOLDER = this.extensionsFolder;
-		process.env.EXTENSION_DEV_PATH = this.coverage ? process.cwd() : undefined;
+		if (this.extensionsFolder) {
+			process.env.EXTENSIONS_FOLDER = this.extensionsFolder;
+		} else {
+			delete process.env.EXTENSIONS_FOLDER;
+		}
+		if (this.coverage) {
+			process.env.EXTENSION_DEV_PATH = process.cwd();
+		} else {
+			delete process.env.EXTENSION_DEV_PATH;
+		}
 		const runner = new VSRunner(
 			this.getExecutablePath(),
 			literalVersion,
@@ -353,7 +411,17 @@ export class CodeUtil {
 			runOptions.cleanup,
 			runOptions.locale,
 		);
-		return await runner.runTests(testFilesPattern, this, runOptions.resources, runOptions.logLevel);
+		try {
+			return await runner.runTests(testFilesPattern, this, runOptions.resources, runOptions.logLevel);
+		} finally {
+			// Restore the original process environment
+			for (const envKey of Object.keys(process.env)) {
+				if (!(envKey in savedEnv)) {
+					delete process.env[envKey];
+				}
+			}
+			Object.assign(process.env, savedEnv);
+		}
 	}
 
 	/**
@@ -383,7 +451,8 @@ export class CodeUtil {
 		await Download.getFile(url, path.join(this.downloadFolder, fileName));
 
 		try {
-			const manifest = require(path.join(this.downloadFolder, fileName));
+			const manifestPath = path.join(this.downloadFolder, fileName);
+			const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
 			return manifest.registrations[0].version;
 		} catch (err) {
 			let version = '';
@@ -454,14 +523,18 @@ export class CodeUtil {
 	 * Check what VS Code version is present in the testing folder
 	 */
 	private getExistingCodeVersion(): string {
+		if (this.cachedCodeVersion) {
+			return this.cachedCodeVersion;
+		}
 		const command = `${this.cliEnv} "${this.getExecutablePath()}" "${this.getCliPath()}"`;
 		let out: Buffer;
 		try {
-			out = childProcess.execSync(`${command} -v`, { env: this.env });
+			out = childProcess.execSync(`${command} -v`, { env: this.env, timeout: 30_000 });
 		} catch (error) {
-			out = childProcess.execSync(`${command} --ms-enable-electron-run-as-node -v`, { env: this.env });
+			out = childProcess.execSync(`${command} --ms-enable-electron-run-as-node -v`, { env: this.env, timeout: 30_000 });
 		}
-		return out.toString().split('\n')[0];
+		this.cachedCodeVersion = out.toString().split('\n')[0];
+		return this.cachedCodeVersion;
 	}
 
 	/**

--- a/packages/extester/src/util/download.ts
+++ b/packages/extester/src/util/download.ts
@@ -16,15 +16,18 @@
  */
 
 import * as fs from 'fs-extra';
-import { promisify } from 'util';
-import stream from 'stream';
+import { promisify } from 'node:util';
+import stream from 'node:stream';
 import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
 
-const retryCount = 3;
+const retryCount = 5;
+const noProxy = process.env.NO_PROXY || process.env.no_proxy;
+
 const httpProxyAgent = !process.env.HTTP_PROXY
 	? undefined
 	: new HttpProxyAgent({
 			proxy: process.env.HTTP_PROXY,
+			...(noProxy ? { noProxy } : {}),
 		});
 
 const rejectUnauthorized = +(process.env.HTTPS_TLS_REJECT_UNAUTHORIZED ?? 1) >= 1;
@@ -32,6 +35,7 @@ const httpsProxyAgent = !process.env.HTTPS_PROXY
 	? undefined
 	: new HttpsProxyAgent({
 			proxy: process.env.HTTPS_PROXY,
+			...(noProxy ? { noProxy } : {}),
 		});
 
 const options = {
@@ -45,33 +49,72 @@ const options = {
 		http: httpProxyAgent,
 		https: httpsProxyAgent,
 	},
+	timeout: {
+		request: 180_000,
+		response: 120_000,
+	},
 	retry: {
 		limit: retryCount,
+		// The default errorCodes list does not include the content-length mismatch
+		// error that `got` raises as ERR_HTTP_CONTENT_LENGTH_MISMATCH (a ReadError).
+		// This intermittent network error is the root cause of flaky VS Code downloads
+		// on CI runners, so we add it (and its generic fallback) here so that got's
+		// built-in exponential-backoff retry fires automatically on these transient
+		// failures instead of surfacing them as fatal errors.
+		errorCodes: [
+			'ETIMEDOUT',
+			'ECONNRESET',
+			'EADDRINUSE',
+			'ECONNREFUSED',
+			'EPIPE',
+			'ENOTFOUND',
+			'ENETUNREACH',
+			'EAI_AGAIN',
+			'ERR_HTTP_CONTENT_LENGTH_MISMATCH',
+			'ERR_READING_RESPONSE_STREAM',
+		],
 	},
 };
 
 export class Download {
 	/**
 	 * Check whether a URL is reachable (HTTP 2xx) without downloading the body.
-	 * Throws if the URL returns a non-2xx status or a network error.
+	 * Retries up to 3 times to handle transient CDN/DNS failures that would
+	 * otherwise cause ChromeDriver version resolution to fall back silently.
 	 */
 	static async checkURL(uri: string): Promise<void> {
 		const got = (await import('got')).default;
-		await got.head(uri, { ...options, retry: { limit: 0 } });
+		await got.head(uri, { ...options, retry: { ...options.retry, limit: 3 } });
 	}
 
-	static async getText(uri: string): Promise<string> {
+	/**
+	 * Fetch text content from a URL and parse it as JSON.
+	 */
+	static async getJSON<T = unknown>(uri: string): Promise<T> {
 		const got = (await import('got')).default;
 		const body = await got(uri, options).text();
-		return JSON.parse(body as string);
+		return JSON.parse(body) as T;
 	}
 
+	/**
+	 * Fetch raw text content from a URL.
+	 */
+	static async getText(uri: string): Promise<string> {
+		const got = (await import('got')).default;
+		return await got(uri, options).text();
+	}
+
+	/**
+	 * Download a file to disk atomically: writes to a `.tmp` file first, then
+	 * renames on success. This prevents partial/truncated downloads from being
+	 * treated as valid cached archives.
+	 */
 	static async getFile(uri: string, destination: string, progress = false): Promise<void> {
+		const tmpDest = `${destination}.tmp`;
 		let lastTick = 0;
 		const got = (await import('got')).default;
 		const dlStream = got.stream(uri, options);
-		// needed in order to enable retry feature:
-		dlStream.once('retry', (newRetryCount: number, error) => {
+		dlStream.on('retry', (newRetryCount: number, error) => {
 			console.warn(`retry(${newRetryCount}): Failed getting ${uri} due to ${error}`);
 		});
 		if (progress) {
@@ -83,8 +126,14 @@ export class Download {
 				}
 			});
 		}
-		const writeStream = fs.createWriteStream(destination);
+		const writeStream = fs.createWriteStream(tmpDest);
 
-		return await promisify(stream.pipeline)(dlStream, writeStream);
+		try {
+			await promisify(stream.pipeline)(dlStream, writeStream);
+			await fs.rename(tmpDest, destination);
+		} catch (err) {
+			await fs.remove(tmpDest).catch(() => {});
+			throw err;
+		}
 	}
 }

--- a/packages/extester/src/util/driverUtil.ts
+++ b/packages/extester/src/util/driverUtil.ts
@@ -50,6 +50,11 @@ export class DriverUtil {
 	 * @param version version to download
 	 */
 	async downloadChromeDriver(version: string, noCache: boolean = false): Promise<string> {
+		// The version string originates from external sources (CLI input, remote
+		// release metadata, the browser's build info). Replace it with a value
+		// rebuilt from its parsed numeric components before it flows into URLs,
+		// filesystem paths, process arguments or log output.
+		version = DriverUtil.sanitizeVersion(version);
 		const url = this.getChromeDriverURL(version);
 		const driverBinary = this.getChromeDriverBinaryPath(version);
 
@@ -62,7 +67,7 @@ export class DriverUtil {
 			}
 			if (localVersion.startsWith(version)) {
 				console.log(`ChromeDriver ${version} exists in local cache, skipping download`);
-				return '';
+				return driverBinary;
 			}
 		}
 
@@ -71,12 +76,17 @@ export class DriverUtil {
 		if (!noCache && fs.existsSync(fileName)) {
 			console.log(`ChromeDriver ${version} exists in storage folder, skipping download`);
 		} else {
-			console.log(`Downloading ChromeDriver ${version} from: ${url}`);
+			console.log(`Downloading ChromeDriver ${version}`);
 			await Download.getFile(url, fileName, true);
 		}
 
-		console.log(`Unpacking ChromeDriver ${version} into ${this.downloadFolder}`);
-		await Unpack.unpack(fileName, this.downloadFolder);
+		// Only unpack if the binary doesn't exist yet or its version doesn't match
+		if (!fs.existsSync(driverBinary) || !(await this.isLocalVersionMatch(version))) {
+			console.log(`Unpacking ChromeDriver ${version} into ${this.downloadFolder}`);
+			await Unpack.unpack(fileName, this.downloadFolder);
+		} else {
+			console.log(`ChromeDriver ${version} binary already present, skipping unpack`);
+		}
 
 		if (process.platform !== 'win32') {
 			fs.chmodSync(driverBinary, 0o755);
@@ -152,16 +162,51 @@ export class DriverUtil {
 	/**
 	 * Check local chrome driver version
 	 */
+	private async isLocalVersionMatch(version: string): Promise<boolean> {
+		try {
+			const local = await this.getLocalDriverVersion(version);
+			return local.startsWith(version);
+		} catch {
+			return false;
+		}
+	}
+
 	private async getLocalDriverVersion(version: string): Promise<string> {
-		const command = `${this.getChromeDriverBinaryPath(version)} -v`;
+		// Invoke the binary directly (no shell) so the path is passed as-is and
+		// cannot be interpreted as shell syntax. The version component is rebuilt
+		// from parsed integers, and the resolved binary path must stay inside the
+		// storage folder — a crafted version or storage value cannot traverse out
+		// or smuggle shell syntax anywhere.
+		version = DriverUtil.sanitizeVersion(version);
+		const binaryPath = path.resolve(this.getChromeDriverBinaryPath(version));
+		const storageRoot = path.resolve(this.downloadFolder) + path.sep;
+		if (!binaryPath.startsWith(storageRoot)) {
+			throw new Error('Resolved ChromeDriver binary path escapes the storage folder');
+		}
 		return new Promise<string>((resolve, reject) => {
-			childProcess.exec(command, (err, stdout) => {
+			childProcess.execFile(binaryPath, ['-v'], { timeout: 15_000 }, (err, stdout) => {
 				if (err) {
 					return reject(new Error(err.message));
 				}
 				resolve(stdout.split(' ')[1]);
 			});
 		});
+	}
+
+	/**
+	 * Parse a ChromeDriver version string (a plain dotted number sequence such
+	 * as 114 or 114.0.5735.90) and rebuild it from its numeric components.
+	 * Throws for any other shape. Returning a string reconstructed from parsed
+	 * integers — never the original input — guarantees that whatever reaches
+	 * URLs, filesystem paths, process arguments or log messages contains only
+	 * digits and dots, regardless of where the input came from.
+	 */
+	private static sanitizeVersion(version: string): string {
+		const parts = version.trim().split('.');
+		if (parts.length === 0 || parts.length > 4 || parts.some((part) => !/^\d{1,10}$/.test(part))) {
+			throw new Error('Invalid ChromeDriver version format');
+		}
+		return parts.map((part) => Number.parseInt(part, 10)).join('.');
 	}
 
 	/**

--- a/packages/extester/src/util/unpack.ts
+++ b/packages/extester/src/util/unpack.ts
@@ -40,7 +40,7 @@ export class Unpack {
 				);
 			} else if (input.toString().endsWith('.zip')) {
 				if (process.platform === 'darwin' || process.platform === 'linux') {
-					exec(`unzip -qo ${input.toString()}`, { cwd: target.toString() }, (err) => {
+					exec(`unzip -qo "${input.toString()}"`, { cwd: target.toString(), timeout: 120_000 }, (err) => {
 						if (err) {
 							reject(new Error(err.message));
 						} else {
@@ -61,7 +61,7 @@ export class Unpack {
 						});
 				}
 			} else {
-				reject(`Unsupported extension for '${input}'`);
+				reject(new Error(`Unsupported extension for '${input}'`));
 			}
 		});
 	}

--- a/packages/locators/lib/1.37.0.ts
+++ b/packages/locators/lib/1.37.0.ts
@@ -220,7 +220,7 @@ const editor = {
 		modifiedEditor: By.className('modified-in-monaco-diff-editor'),
 	},
 	WebView: {
-		iframe: By.css(`iframe[class='webview ready']`),
+		iframe: By.css(`iframe.webview.ready`),
 		activeFrame: By.id('active-frame'),
 	},
 	ExtensionEditorView: {

--- a/packages/page-objects/src/components/AbstractElement.ts
+++ b/packages/page-objects/src/components/AbstractElement.ts
@@ -185,7 +185,8 @@ export abstract class AbstractElement extends WebElement {
 				const isRecoverable =
 					err.name === 'StaleElementReferenceError' ||
 					err.name === 'ElementNotInteractableError' ||
-					/element.*(detached|not interactable)/i.test(err.message);
+					err.name === 'ElementClickInterceptedError' ||
+					/element.*(detached|not interactable|click intercepted)/i.test(err.message);
 
 				if (isRecoverable && attempt < maxRetries) {
 					try {

--- a/packages/page-objects/src/components/ElementWithContextMenu.ts
+++ b/packages/page-objects/src/components/ElementWithContextMenu.ts
@@ -27,25 +27,27 @@ export abstract class ElementWithContextMenu extends AbstractElement {
 	 * Open context menu on the element
 	 */
 	async openContextMenu(): Promise<ContextMenu> {
-		const workbench = await this.getDriver().findElement(ElementWithContextMenu.locators.Workbench.constructor);
-		const menus = await workbench.findElements(ElementWithContextMenu.locators.ContextMenu.contextView);
+		return await this.withRecovery(async (self) => {
+			const workbench = await self.getDriver().findElement(ElementWithContextMenu.locators.Workbench.constructor);
+			const menus = await workbench.findElements(ElementWithContextMenu.locators.ContextMenu.contextView);
 
-		if (menus.length < 1) {
-			await this.getDriver().actions().contextClick(this).perform();
-			await this.getDriver().wait(until.elementLocated(ElementWithContextMenu.locators.ContextMenu.contextView), 2000);
-			return new ContextMenu(workbench).wait();
-		} else if ((await workbench.findElements(ElementWithContextMenu.locators.ContextMenu.viewBlock)).length > 0) {
-			await this.getDriver().actions().contextClick(this).perform();
-			try {
-				await this.getDriver().wait(until.elementIsNotVisible(this), 1000);
-			} catch (err) {
-				if (!(err instanceof error.StaleElementReferenceError)) {
-					throw err;
+			if (menus.length < 1) {
+				await self.getDriver().actions().contextClick(self).perform();
+				await self.getDriver().wait(until.elementLocated(ElementWithContextMenu.locators.ContextMenu.contextView), 2000);
+				return new ContextMenu(workbench).wait();
+			} else if ((await workbench.findElements(ElementWithContextMenu.locators.ContextMenu.viewBlock)).length > 0) {
+				await self.getDriver().actions().contextClick(self).perform();
+				try {
+					await self.getDriver().wait(until.elementIsNotVisible(self), 1000);
+				} catch (err) {
+					if (!(err instanceof error.StaleElementReferenceError)) {
+						throw err;
+					}
 				}
 			}
-		}
-		await this.getDriver().actions().contextClick(this).perform();
+			await self.getDriver().actions().contextClick(self).perform();
 
-		return new ContextMenu(workbench).wait();
+			return new ContextMenu(workbench).wait();
+		});
 	}
 }

--- a/packages/page-objects/src/components/WebviewMixin.ts
+++ b/packages/page-objects/src/components/WebviewMixin.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Locator, WebElement, until } from 'selenium-webdriver';
+import { Locator, WebElement, error } from 'selenium-webdriver';
 import { AbstractElement } from './AbstractElement';
 
 /**
@@ -50,7 +50,9 @@ export interface WebviewMixinType {
 export default function <TBase extends Constructor<WebviewMixable>>(Base: TBase): Constructor<InstanceType<TBase> & WebviewMixinType> {
 	return class extends Base implements WebviewMixinType {
 		/**
-		 * Cannot use static element, since this class is unnamed.
+		 * Window handle captured once at switchToFrame() time so that switchBack()
+		 * always returns to the correct top-level context even when called from
+		 * within a nested frame.
 		 */
 		private handle: string | undefined;
 
@@ -83,30 +85,100 @@ export default function <TBase extends Constructor<WebviewMixable>>(Base: TBase)
 		 * This allows using the findWebElement methods.
 		 * Note that only elements inside the webview iframe will be accessible.
 		 * Use the switchBack method to switch to the original context.
+		 *
+		 * The method polls for both the outer iframe and the inner active-frame to
+		 * appear in the DOM under a single shared deadline, so `timeout` is always
+		 * honoured regardless of how long each phase takes.  The driver is always
+		 * returned to the top-level context before any error is thrown.
+		 *
+		 * @throws Error when the webview iframe cannot be located within the timeout
 		 */
 		async switchToFrame(timeout: number = 5000): Promise<void> {
 			if (!this.handle) {
 				this.handle = await this.getDriver().getWindowHandle();
 			}
 
-			const view = await this.getViewToSwitchTo();
+			const deadline = Date.now() + timeout;
+			const pollInterval = 200;
+			const minPhase2Budget = Math.min(5000, Math.floor(timeout / 3));
 
-			if (!view) {
-				return;
+			// Phase 1 — poll for the outer webview iframe. Stop early to
+			// guarantee at least minPhase2Budget ms for the inner-frame lookup.
+			let view: WebElement | undefined;
+			while (Date.now() < deadline - minPhase2Budget) {
+				try {
+					view = await this.getViewToSwitchTo();
+				} catch (e) {
+					if (!(e instanceof error.StaleElementReferenceError || e instanceof error.NoSuchElementError)) {
+						throw e;
+					}
+				}
+				if (view) {
+					break;
+				}
+				await this.getDriver().sleep(pollInterval);
 			}
 
-			await this.getDriver().switchTo().frame(view);
+			if (!view) {
+				throw new Error(
+					`WebviewMixin.switchToFrame: webview iframe was not found within ${timeout}ms. ` +
+						`The webview may not have been opened, or the locator no longer matches the current VS Code version. ` +
+						`See https://github.com/redhat-developer/vscode-extension-tester/issues/2450`,
+				);
+			}
 
-			await this.getDriver().wait(until.elementLocated(AbstractElement.locators.WebView.activeFrame), timeout);
-			const frame = await this.getDriver().findElement(AbstractElement.locators.WebView.activeFrame);
+			// Phase 2 — switch into the outer iframe, then poll for the inner
+			// active-frame under the remaining budget (at least minPhase2Budget ms).
+			try {
+				await this.getDriver().switchTo().frame(view);
+			} catch (e) {
+				if (e instanceof error.StaleElementReferenceError) {
+					throw new Error(
+						`WebviewMixin.switchToFrame: outer iframe became stale during frame switch. ` +
+							`See https://github.com/redhat-developer/vscode-extension-tester/issues/2450`,
+					);
+				}
+				throw e;
+			}
+
+			let frame: WebElement | undefined;
+			while (Date.now() < deadline) {
+				try {
+					const frames = await this.getDriver().findElements(AbstractElement.locators.WebView.activeFrame);
+					if (frames.length > 0) {
+						frame = frames[0];
+						break;
+					}
+				} catch (e) {
+					if (!(e instanceof error.StaleElementReferenceError || e instanceof error.NoSuchElementError)) {
+						await this.getDriver().switchTo().window(this.handle);
+						throw e;
+					}
+				}
+				await this.getDriver().sleep(pollInterval);
+			}
+
+			if (!frame) {
+				// Return to top-level before throwing so callers are not left inside a frame.
+				await this.getDriver().switchTo().window(this.handle);
+				throw new Error(
+					`WebviewMixin.switchToFrame: active-frame iframe was not found within ${timeout}ms. ` +
+						`The webview content may still be loading. ` +
+						`See https://github.com/redhat-developer/vscode-extension-tester/issues/2450`,
+				);
+			}
+
 			await this.getDriver().switchTo().frame(frame);
 		}
 
 		/**
-		 * Switch the underlying webdriver back to the original window
+		 * Switch the underlying webdriver back to the original window.
+		 * Uses the handle captured at switchToFrame() time; safe to call even when
+		 * the driver context is already at the top level.
 		 */
 		async switchBack(): Promise<void> {
 			if (!this.handle) {
+				// switchToFrame() was never called — capture and stay at top level
 				this.handle = await this.getDriver().getWindowHandle();
 			}
 			return await this.getDriver().switchTo().window(this.handle);

--- a/packages/page-objects/src/components/activityBar/ViewControl.ts
+++ b/packages/page-objects/src/components/activityBar/ViewControl.ts
@@ -25,6 +25,12 @@ import { satisfies } from 'compare-versions';
  * Page object representing a view container item in the activity bar
  */
 export class ViewControl extends ElementWithContextMenu {
+	/**
+	 * Title of this control, cached on the first successful getTitle() call so the
+	 * control can be re-located in the activity bar after its element goes stale.
+	 */
+	private cachedTitle: string | undefined;
+
 	constructor(element: WebElement, bar: ActivityBar) {
 		super(element, bar);
 	}
@@ -34,15 +40,19 @@ export class ViewControl extends ElementWithContextMenu {
 	 * @returns Promise resolving to SideBarView object representing the opened view
 	 */
 	async openView(): Promise<SideBarView> {
-		// Check whether view is already open
-		const klass = (await this.getAttribute(ViewControl.locators.ViewControl.attribute))!;
+		// Use safeGetKlass so a stale reference is transparently re-fetched.
+		const klass = await this.safeGetKlass();
 		if (klass.indexOf(ViewControl.locators.ViewControl.klass) < 0) {
-			await this.click();
+			await this.safeClick();
 			// Wait for view to be marked as active
 			await this.getWaitHelper().forCondition(
 				async () => {
-					const newKlass = (await this.getAttribute(ViewControl.locators.ViewControl.attribute))!;
-					return newKlass.includes(ViewControl.locators.ViewControl.klass);
+					try {
+						const newKlass = await this.safeGetKlass();
+						return newKlass.includes(ViewControl.locators.ViewControl.klass);
+					} catch {
+						return false;
+					}
 				},
 				{ timeout: 2000, pollInterval: 100 },
 			);
@@ -65,9 +75,9 @@ export class ViewControl extends ElementWithContextMenu {
 	 * @returns Promise resolving when the view closes
 	 */
 	async closeView(): Promise<void> {
-		const klass = (await this.getAttribute(ViewControl.locators.ViewControl.attribute))!;
+		const klass = await this.safeGetKlass();
 		if (klass.indexOf(ViewControl.locators.ViewControl.klass) > -1) {
-			await this.click();
+			await this.safeClick();
 		}
 	}
 
@@ -76,6 +86,35 @@ export class ViewControl extends ElementWithContextMenu {
 	 */
 	async getTitle(): Promise<string> {
 		const badge = await this.findElement(ViewControl.locators.ViewControl.badge);
-		return (await badge.getAttribute('aria-label'))!;
+		const title = (await badge.getAttribute('aria-label'))!;
+		this.cachedTitle = title;
+		return title;
+	}
+
+	/**
+	 * Re-locate this control in the activity bar by its cached title.
+	 * Used by withRecovery()-based helpers (safeClick, safeGetKlass) when the
+	 * stored element reference goes stale, e.g. after the activity bar re-renders.
+	 */
+	protected override async reinitialize(): Promise<this> {
+		if (!this.cachedTitle) {
+			throw new Error(`ViewControl: element is stale and no cached title is available to re-locate it`);
+		}
+		// getViewControls() always queries live elements, so the new reference is fresh.
+		const fresh = await new ActivityBar().getViewControl(this.cachedTitle);
+		if (!fresh) {
+			throw new Error(`ViewControl: could not re-locate stale element '${this.cachedTitle}' in the activity bar`);
+		}
+		return fresh as this;
+	}
+
+	/**
+	 * Read the CSS class attribute from this element, recovering transparently if
+	 * the stored reference has become stale.
+	 */
+	private async safeGetKlass(): Promise<string> {
+		return await this.withRecovery(async (self) => {
+			return (await self.getAttribute(ViewControl.locators.ViewControl.attribute))!;
+		});
 	}
 }

--- a/packages/page-objects/src/components/bottomBar/BottomBarPanel.ts
+++ b/packages/page-objects/src/components/bottomBar/BottomBarPanel.ts
@@ -47,7 +47,7 @@ export class BottomBarPanel extends AbstractElement {
 				await this.wait();
 			} else {
 				await this.closePanel();
-				await this.getDriver().wait(until.elementIsNotVisible(this));
+				await this.getDriver().wait(until.elementIsNotVisible(this), 5_000);
 			}
 		}
 	}
@@ -128,17 +128,35 @@ export class BottomBarPanel extends AbstractElement {
 
 	private async resize(label: string) {
 		await this.toggle(true);
-		let action!: WebElement;
-		try {
-			action = await this.findElement(BottomBarPanel.locators.BottomBarPanel.globalActions).findElement(
-				BottomBarPanel.locators.BottomBarPanel.action(label),
-			);
-		} catch (err) {
-			// the panel is already maximized
-		}
-		if (action) {
-			await action.click();
-		}
+		// The resize action button may briefly be non-interactable (or get replaced)
+		// while the panel's open/maximize animation is running — poll the click
+		// instead of failing on the first attempt.
+		await this.getDriver()
+			.wait(
+				async () => {
+					let action: WebElement;
+					try {
+						action = await this.findElement(BottomBarPanel.locators.BottomBarPanel.globalActions).findElement(
+							BottomBarPanel.locators.BottomBarPanel.action(label),
+						);
+					} catch (err) {
+						// the panel is already maximized/restored — the action is absent
+						return true;
+					}
+					try {
+						await action.click();
+						return true;
+					} catch (err) {
+						// not interactable or stale mid-animation — retry
+						return false;
+					}
+				},
+				5000,
+				`BottomBarPanel: could not click the '${label}' action`,
+			)
+			.catch(() => {
+				// keep previous lenient behavior — resize is best-effort
+			});
 	}
 
 	public async closePanel() {

--- a/packages/page-objects/src/components/editor/ContentAssist.ts
+++ b/packages/page-objects/src/components/editor/ContentAssist.ts
@@ -31,34 +31,123 @@ export class ContentAssist extends Menu {
 	 * until the item is found, or the end is reached
 	 *
 	 * @param name name/text to search by
+	 * @param timeout overall time budget in ms for the search (default 30000)
 	 * @returns Promise resolving to ContentAssistItem object if found, undefined otherwise
 	 */
-	async getItem(name: string): Promise<ContentAssistItem | undefined> {
-		let lastItem = false;
+	async getItem(name: string, timeout: number = 30000): Promise<ContentAssistItem | undefined> {
+		const deadline = Date.now() + timeout;
 		const scrollable = await this.findElement(ContentAssist.locators.ContentAssist.itemList);
 
+		await this.getDriver().wait(
+			async () => {
+				return (await this.isLoaded()) && (await this.findElements(ContentAssist.locators.ContentAssist.itemRow)).length > 0;
+			},
+			Math.min(10000, Math.max(1000, deadline - Date.now())),
+			'Content assist item list did not populate',
+		);
+
+		// Scroll back to the top of the list in case it is not there already
 		let firstItem = await this.findElements(ContentAssist.locators.ContentAssist.firstItem);
-		while (firstItem.length < 1) {
+		while (firstItem.length < 1 && Date.now() < deadline) {
 			await scrollable.sendKeys(Key.PAGE_UP, Key.NULL);
+			await this.getWaitHelper().sleep(100);
 			firstItem = await this.findElements(ContentAssist.locators.ContentAssist.firstItem);
 		}
 
-		while (!lastItem) {
-			const items = await this.getItems();
-
-			for (const item of items) {
-				if ((await item.getLabel()) === name) {
-					return item;
+		while (Date.now() < deadline) {
+			let rows: ContentAssistRowSnapshot[];
+			try {
+				rows = await this.snapshotVisibleRows();
+			} catch (err) {
+				if (err instanceof error.StaleElementReferenceError) {
+					// The list re-rendered mid-read — take a fresh snapshot
+					continue;
 				}
-				lastItem = lastItem || (await item.getAttribute('data-last-element')) === 'true';
+				throw err;
 			}
-			if (!lastItem) {
-				await scrollable.sendKeys(Key.PAGE_DOWN);
-				// Minimal delay for scroll to render new items
-				await this.getWaitHelper().sleep(100);
+			const match = rows.find((row) => row.label === name);
+			if (match) {
+				try {
+					return await new ContentAssistItem(match.element, this).wait();
+				} catch (err) {
+					if (err instanceof error.StaleElementReferenceError) {
+						continue;
+					}
+					throw err;
+				}
 			}
+			if (rows.some((row) => row.last)) {
+				// Reached the end of the list without finding the item
+				return undefined;
+			}
+			const maxIndex = rows.reduce((max, row) => Math.max(max, row.index), -1);
+			await scrollable.sendKeys(Key.PAGE_DOWN);
+			// Wait for the visible range to actually move instead of sleeping a fixed amount
+			await this.getDriver()
+				.wait(
+					async () => {
+						const next = await this.snapshotVisibleRows().catch(() => undefined);
+						return next !== undefined && (next.some((row) => row.last) || next.reduce((max, row) => Math.max(max, row.index), -1) > maxIndex);
+					},
+					Math.min(2000, Math.max(200, deadline - Date.now())),
+				)
+				.catch(() => {
+					// The list did not move — keep looping, the deadline will end the search
+				});
 		}
+		return undefined;
 	}
+
+	/**
+	 * Read all currently rendered suggestion rows in a single script call.
+	 * Returns the row elements together with their label text, virtual list index
+	 * and whether the row is marked as the last element of the list.
+	 */
+	private async snapshotVisibleRows(): Promise<ContentAssistRowSnapshot[]> {
+		const container = await this.findElement(ContentAssist.locators.ContentAssist.itemRows);
+		const rowLocator = ContentAssist.locators.ContentAssist.itemRow as unknown as SerializableLocator;
+		const labelLocator = ContentAssist.locators.ContentAssist.itemLabel as unknown as SerializableLocator;
+		const raw = (await this.getDriver().executeScript(
+			ContentAssist.SNAPSHOT_ROWS_SCRIPT,
+			container,
+			rowLocator.using,
+			rowLocator.value,
+			labelLocator.using,
+			labelLocator.value,
+		)) as { element: WebElement; label: string; index: number; last: boolean }[];
+		return raw.map((row) => ({ element: row.element, label: row.label, index: row.index, last: row.last }));
+	}
+
+	private static readonly SNAPSHOT_ROWS_SCRIPT = `
+		var container = arguments[0];
+		var rowUsing = arguments[1], rowValue = arguments[2];
+		var labelUsing = arguments[3], labelValue = arguments[4];
+		function findAll(root, using, value) {
+			if (using === 'xpath') {
+				var out = [];
+				var it = document.evaluate(value, root, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
+				for (var i = 0; i < it.snapshotLength; i++) { out.push(it.snapshotItem(i)); }
+				return out;
+			}
+			return Array.prototype.slice.call(root.querySelectorAll(value));
+		}
+		function findOne(root, using, value) {
+			if (using === 'xpath') {
+				return document.evaluate(value, root, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+			}
+			return root.querySelector(value);
+		}
+		return findAll(container, rowUsing, rowValue).map(function (row) {
+			var labelEl = findOne(row, labelUsing, labelValue);
+			var label = labelEl ? (labelEl.innerText !== undefined ? labelEl.innerText : labelEl.textContent) : '';
+			return {
+				element: row,
+				label: (label || '').trim(),
+				index: parseInt(row.getAttribute('data-index') || '-1', 10),
+				last: row.getAttribute('data-last-element') === 'true'
+			};
+		});
+	`;
 
 	/**
 	 * Get all visible content assist items
@@ -102,6 +191,18 @@ export class ContentAssist extends Menu {
 		}
 		return true;
 	}
+}
+
+interface SerializableLocator {
+	using: string;
+	value: string;
+}
+
+interface ContentAssistRowSnapshot {
+	element: WebElement;
+	label: string;
+	index: number;
+	last: boolean;
 }
 
 /**

--- a/packages/page-objects/src/components/editor/CustomEditor.ts
+++ b/packages/page-objects/src/components/editor/CustomEditor.ts
@@ -16,7 +16,7 @@
  */
 
 import { Key } from 'selenium-webdriver';
-import { Editor, InputBox, WebView } from '../..';
+import { Editor, EditorGroup, EditorView, InputBox, WebView } from '../..';
 
 /**
  * Page object for custom editors
@@ -27,7 +27,7 @@ export class CustomEditor extends Editor {
 	 * @returns WebView page object
 	 */
 	getWebView(): WebView {
-		return new WebView();
+		return new WebView(this.enclosingItem as EditorView | EditorGroup);
 	}
 
 	/**

--- a/packages/page-objects/src/components/editor/EditorView.ts
+++ b/packages/page-objects/src/components/editor/EditorView.ts
@@ -72,7 +72,8 @@ export class EditorView extends AbstractElement {
 			return groups[groupIndex].closeAllEditors();
 		}
 
-		while (groups.length > 0 && (await groups[0].getOpenEditorTitles()).length > 0) {
+		const deadline = Date.now() + 60000;
+		while (groups.length > 0 && (await groups[0].getOpenEditorTitles()).length > 0 && Date.now() < deadline) {
 			await groups[0].closeAllEditors();
 			// Brief wait for DOM to settle after closing editors
 			await this.getWaitHelper().sleep(500);
@@ -272,7 +273,28 @@ export class EditorGroup extends AbstractElement {
 	async closeEditor(title: string): Promise<void> {
 		const tab = await this.getTabByTitle(title);
 		const closeButton = await tab.findElement(EditorView.locators.EditorView.closeTab);
-		await closeButton.click();
+		// VS Code renders hover tooltip overlays (<div class="hover-contents">) that can
+		// intercept the click (ElementClickInterceptedError) on CI. Retry with an
+		// increasing delay; fall back to a JS-executor click on the last attempt which
+		// bypasses overlay elements entirely.
+		const maxAttempts = 3;
+		for (let attempt = 0; attempt < maxAttempts; attempt++) {
+			try {
+				await closeButton.click();
+				return;
+			} catch (err: any) {
+				if (err.name !== 'ElementClickInterceptedError' || attempt === maxAttempts - 1) {
+					// On the final attempt use executeScript to bypass the overlay, then return.
+					if (err.name === 'ElementClickInterceptedError') {
+						await this.getDriver().executeScript('arguments[0].click()', closeButton);
+						return;
+					}
+					throw err;
+				}
+				// Brief back-off so the tooltip has time to dismiss before the next attempt.
+				await this.getWaitHelper().sleep(300 * (attempt + 1));
+			}
+		}
 	}
 
 	/**
@@ -280,8 +302,10 @@ export class EditorGroup extends AbstractElement {
 	 * @returns Promise resolving once all tabs have had their close button pressed
 	 */
 	async closeAllEditors(): Promise<void> {
+		const deadline = Date.now() + 30000;
 		let titles = await this.getOpenEditorTitles();
-		while (titles.length > 0) {
+		while (titles.length > 0 && Date.now() < deadline) {
+			const previousCount = titles.length;
 			await this.closeEditor(titles[0]);
 			try {
 				// check if the group still exists
@@ -290,6 +314,18 @@ export class EditorGroup extends AbstractElement {
 				break;
 			}
 			titles = await this.getOpenEditorTitles();
+			if (titles.length >= previousCount) {
+				try {
+					await this.getDriver().actions().sendKeys('\uE00C').perform();
+					await this.getWaitHelper().sleep(500);
+				} catch {
+					/* ignore */
+				}
+				titles = await this.getOpenEditorTitles();
+				if (titles.length >= previousCount) {
+					break;
+				}
+			}
 		}
 	}
 

--- a/packages/page-objects/src/components/editor/SettingsEditor.ts
+++ b/packages/page-objects/src/components/editor/SettingsEditor.ts
@@ -93,7 +93,24 @@ export class SettingsEditor extends Editor {
 			{ timeout: 5000, stabilityInterval: 300, stableChecks: 2 },
 		);
 
+		// The count can stabilize before the search filter has been applied on slow
+		// machines — poll the rendered rows until the requested setting shows up
+		// instead of sampling them a single time.
+		const deadline = Date.now() + 10_000;
 		let setting!: Setting;
+		for (;;) {
+			const found = await this.scanForSettingItem(title, category);
+			if (found) {
+				return found;
+			}
+			if (Date.now() >= deadline) {
+				return setting;
+			}
+			await this.getWaitHelper().sleep(500);
+		}
+	}
+
+	private async scanForSettingItem(title: string, category: string): Promise<Setting | undefined> {
 		const items = await this.findElements(SettingsEditor.locators.SettingsEditor.itemRow);
 		for (const item of items) {
 			try {
@@ -117,7 +134,7 @@ export class SettingsEditor extends Editor {
 				// do nothing
 			}
 		}
-		return setting;
+		return undefined;
 	}
 
 	/**

--- a/packages/page-objects/src/components/editor/TextEditor.ts
+++ b/packages/page-objects/src/components/editor/TextEditor.ts
@@ -17,7 +17,7 @@
 
 import { ContentAssist, ContextMenu, InputBox, Workbench } from '../..';
 import { Key, until, WebElement } from 'selenium-webdriver';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { StatusBar } from '../statusBar/StatusBar';
 import { Editor } from './Editor';
 import { ElementWithContextMenu } from '../ElementWithContextMenu';
@@ -41,7 +41,7 @@ export class TextEditor extends Editor {
 	async isDirty(): Promise<boolean> {
 		const tab = await this.enclosingItem.findElement(TextEditor.locators.TextEditor.activeTab);
 		const klass = (await tab.getAttribute('class'))!;
-		return klass.indexOf('dirty') >= 0;
+		return klass.includes('dirty');
 	}
 
 	/**
@@ -186,6 +186,13 @@ export class TextEditor extends Editor {
 	 * @returns Promise resolving once the text is deleted
 	 */
 	async clearText(): Promise<void> {
+		// Dismiss any open menu or overlay first (e.g. context menu left open after
+		// formatDocument), then focus the editor container so the inputArea becomes
+		// interactable.  We press Escape via the driver (safe regardless of focus) and
+		// click the outer editor element — NOT the native-edit-context, which cannot
+		// receive a synthetic click when it is not the active focus target.
+		await this.getDriver().actions().sendKeys(Key.ESCAPE).perform();
+		await this.enclosingItem.click();
 		return this.withRecovery(async (self) => {
 			const input = await self.findElement(TextEditor.locators.Editor.inputArea);
 			await input.sendKeys(Key.chord(TextEditor.ctlKey, 'a'));
@@ -364,15 +371,18 @@ export class TextEditor extends Editor {
 	async setCursor(line: number, column: number, timeout: number = 2_500): Promise<void> {
 		const input = await new Workbench().openCommandPrompt();
 		await input.setText(`:${line},${column}`);
-		// Wait for input to be processed - check for quick picks appearing
-		await this.getWaitHelper().forCondition(
-			async () => {
-				const picks = await input.getQuickPicks().catch(() => []);
-				return picks.length > 0;
-			},
-			{ timeout: 1000, pollInterval: 50 },
-		);
-		await input.selectQuickPick(0);
+		try {
+			await this.getWaitHelper().forCondition(
+				async () => {
+					const picks = await input.getQuickPicks().catch(() => []);
+					return picks.length > 0;
+				},
+				{ timeout: 2000, pollInterval: 50 },
+			);
+			await input.selectQuickPick(0);
+		} catch {
+			await input.confirm();
+		}
 		await this.waitForCursorPositionAt(line, column, timeout);
 	}
 
@@ -613,15 +623,33 @@ export class TextEditor extends Editor {
 	 * Get the cursor's coordinates as an array of two numbers: `[line, column]`
 	 *
 	 * **Caution** line & column coordinates do not start at `0` but at `1`!
+	 *
+	 * @param timeout ms to wait for the status bar to show a valid position (default 5000)
 	 */
-	async getCoordinates(): Promise<[number, number]> {
-		const coords: number[] = [];
+	async getCoordinates(timeout: number = 5_000): Promise<[number, number]> {
 		const statusBar = new StatusBar();
-		const coordinates = <RegExpMatchArray>(await statusBar.getCurrentPosition()).match(/\d+/g);
-		for (const c of coordinates) {
-			coords.push(+c);
-		}
-		return [coords[0], coords[1]];
+		// The status bar position item may not update immediately after a cursor move,
+		// especially on slow CI runners. Poll until it returns a valid "Ln X, Col Y" string.
+		let positionText: string = '';
+		await this.getDriver().wait(
+			async () => {
+				try {
+					const text = await statusBar.getCurrentPosition();
+					const match = text.match(/\d+/g);
+					if (match && match.length >= 2) {
+						positionText = text;
+						return true;
+					}
+				} catch {
+					// Status bar item not yet available — keep polling
+				}
+				return false;
+			},
+			timeout,
+			`Status bar did not show a valid cursor position within ${timeout}ms`,
+		);
+		const coordinates = <RegExpMatchArray>positionText.match(/\d+/g);
+		return [+coordinates[0], +coordinates[1]];
 	}
 
 	private async getTabSize(): Promise<number> {
@@ -648,7 +676,7 @@ export class TextEditor extends Editor {
 			: lineOverlay;
 		const breakPoint = await breakpointContainer.findElements(TextEditor.locators.TextEditor.breakpoint.generalSelector);
 		if (breakPoint.length > 0) {
-			if (this.breakPoints.indexOf(line) !== -1) {
+			if (this.breakPoints.includes(line)) {
 				await breakPoint[this.breakPoints.indexOf(line)].click();
 				// Wait for breakpoint to be removed
 				await this.getWaitHelper().forCondition(
@@ -741,16 +769,25 @@ export class TextEditor extends Editor {
 		const breakpoints: Breakpoint[] = [];
 
 		const breakpointLocators = Breakpoint.locators.TextEditor.breakpoint;
-		const breakpointContainer = satisfies(TextEditor.versionInfo.version, '>=1.80.0')
-			? await this.findElement(TextEditor.locators.TextEditor.glyphMarginWidget)
-			: this;
+		const isNewVersion = satisfies(TextEditor.versionInfo.version, '>=1.80.0');
+		const breakpointContainer = isNewVersion ? await this.findElement(TextEditor.locators.TextEditor.glyphMarginWidget) : this;
 		const breakpointsSelectors = await breakpointContainer.findElements(breakpointLocators.generalSelector);
+
+		// When a debug session is paused at a breakpoint, VS Code renders two overlapping
+		// elements with the `codicon-debug-breakpoint` class at the same vertical position
+		// (the regular breakpoint dot and the stackframe arrow). Deduplicate by `top` so
+		// that each line contributes at most one Breakpoint.
+		const seenTops = new Set<string>();
 
 		for (const breakpointSelector of breakpointsSelectors) {
 			try {
 				let lineElement: WebElement;
-				if (satisfies(TextEditor.versionInfo.version, '>=1.80.0')) {
+				if (isNewVersion) {
 					const styleTopAttr = await breakpointSelector.getCssValue('top');
+					if (seenTops.has(styleTopAttr)) {
+						continue;
+					}
+					seenTops.add(styleTopAttr);
 					lineElement = await this.findElement(TextEditor.locators.TextEditor.marginArea).findElement(
 						TextEditor.locators.TextEditor.lineElement(styleTopAttr),
 					);
@@ -774,13 +811,22 @@ export class TextEditor extends Editor {
 	 */
 	async getCodeLenses(): Promise<CodeLens[]> {
 		const lenses: CodeLens[] = [];
-		const widgets = await this.findElement(TextEditor.locators.TextEditor.contentWidgets);
-		const items = await widgets.findElements(TextEditor.locators.TextEditor.contentWidgetsElements);
+		// Use findElements so that a missing/not-yet-visible contentWidgets container
+		// returns an empty array rather than throwing a TimeoutError.  The caller
+		// (or the before-hook poll loop) is responsible for retrying until lenses appear.
+		const widgetContainers = await this.findElements(TextEditor.locators.TextEditor.contentWidgets);
+		if (widgetContainers.length === 0) {
+			return lenses;
+		}
+		const items = await widgetContainers[0].findElements(TextEditor.locators.TextEditor.contentWidgetsElements);
 		for (const item of items) {
 			try {
 				lenses.push(await new CodeLens(item, this).wait());
 			} catch (e: any) {
-				if (e.name === 'StaleElementReferenceError') {
+				// Skip stale or not-yet-visible lens elements.  TimeoutError means the
+				// lens widget exists in the DOM but is not visible yet (e.g. the editor
+				// is still rendering); the caller's poll loop will retry the whole call.
+				if (e.name === 'StaleElementReferenceError' || e.name === 'TimeoutError') {
 					continue;
 				}
 				throw e;
@@ -862,7 +908,7 @@ class Selection extends ElementWithContextMenu {
 			let shadowRoot;
 			const webdriverCapabilities = await (this.getDriver() as ChromiumWebDriver).getCapabilities();
 			const chromiumVersion = webdriverCapabilities.getBrowserVersion();
-			if (chromiumVersion && parseInt(chromiumVersion.split('.')[0]) >= 96) {
+			if (chromiumVersion && Number.parseInt(chromiumVersion.split('.')[0]) >= 96) {
 				shadowRoot = await shadowRootHost[0].getShadowRoot();
 				return new ContextMenu(await shadowRoot.findElement(TextEditor.locators.TextEditor.monacoMenuContainer)).wait();
 			} else {
@@ -1072,8 +1118,12 @@ export class FindWidget extends AbstractElement {
 
 		const btn = await element.findElement(FindWidget.locators.FindWidget.button(title));
 		await btn.click();
-		// Wait for button action to complete
-		await this.getWaitHelper().forStable(element, { timeout: 500 });
+		// Give the widget a moment to settle after the action (animations, relayout).
+		// Best-effort: a slow animation must not fail the interaction that already
+		// happened, so a stability timeout is not an error here.
+		await this.getWaitHelper()
+			.forStable(element, { timeout: 2000 })
+			.catch(() => undefined);
 	}
 
 	private async setText(text: string, composite: WebElement) {

--- a/packages/page-objects/src/components/editor/WebView.ts
+++ b/packages/page-objects/src/components/editor/WebView.ts
@@ -27,7 +27,12 @@ import { findBestContainingElement } from '../../locators/locators';
 class WebViewBase extends Editor {
 	async getViewToSwitchTo(): Promise<WebElement | undefined> {
 		const frames = await this.getDriver().findElements(WebViewBase.locators.WebView.iframe);
-		return findBestContainingElement(await this.getRect(), frames);
+		if (frames.length === 0) {
+			return undefined;
+		}
+		// Try geometry-based selection first; fall back to the first available frame
+		// when the editor container has not been laid out yet (common on slow CI runners).
+		return (await findBestContainingElement(await this.getRect(), frames)) ?? frames[0];
 	}
 }
 

--- a/packages/page-objects/src/components/menu/ContextMenu.ts
+++ b/packages/page-objects/src/components/menu/ContextMenu.ts
@@ -84,7 +84,7 @@ export class ContextMenu extends Menu {
 		await actions.clear();
 		await this.getDriver().actions().sendKeys(Key.ESCAPE).perform();
 		try {
-			await this.getDriver().wait(until.elementIsNotVisible(this));
+			await this.getDriver().wait(until.elementIsNotVisible(this), 5_000);
 		} catch (err) {
 			if (!(err instanceof error.StaleElementReferenceError)) {
 				throw err;
@@ -144,7 +144,7 @@ export class ContextMenuItem extends MenuItem {
 				const actions = this.getDriver().actions();
 				await actions.clear();
 				await this.getDriver().actions().sendKeys(Key.ESCAPE).perform();
-				await this.getDriver().wait(until.elementIsNotVisible(this));
+				await this.getDriver().wait(until.elementIsNotVisible(this), 5_000);
 			}
 		} catch (err) {
 			if (!(err instanceof error.StaleElementReferenceError)) {

--- a/packages/page-objects/src/components/menu/Menu.ts
+++ b/packages/page-objects/src/components/menu/Menu.ts
@@ -65,9 +65,11 @@ export abstract class Menu extends AbstractElement {
 			if (!item) {
 				return parent;
 			}
+			// Guard with an explicit timeout so the wait never hangs indefinitely
+			// on CI where the implicit/default Selenium timeout may be 0 or very low.
 			await Menu.driver.wait(async function () {
 				return (await item.isDisplayed()) && (await item.isEnabled());
-			});
+			}, 5000);
 			const submenu = await item.select();
 			if (submenu) {
 				parent = submenu;

--- a/packages/page-objects/src/components/sidebar/ViewItem.ts
+++ b/packages/page-objects/src/components/sidebar/ViewItem.ts
@@ -93,6 +93,7 @@ export abstract class TreeItem extends ViewItem {
 	async expand(): Promise<void> {
 		if ((await this.isExpandable()) && !(await this.isExpanded())) {
 			await (await this.findTwistie()).click();
+			await this.getDriver().wait(() => this.isExpanded(), 5000, 'Tree item did not expand within 5s');
 		}
 	}
 

--- a/packages/page-objects/src/components/sidebar/tree/default/DefaultTreeSection.ts
+++ b/packages/page-objects/src/components/sidebar/tree/default/DefaultTreeSection.ts
@@ -45,7 +45,13 @@ export class DefaultTreeSection extends TreeSection {
 		const container = await this.findElement(DefaultTreeSection.locators.DefaultTreeSection.rowContainer);
 		await container.sendKeys(Key.HOME);
 		let item: TreeItem | undefined = undefined;
+		const maxIterations = 500;
+		let iteration = 0;
 		do {
+			if (iteration++ >= maxIterations) {
+				console.warn(`findItem('${label}'): exceeded ${maxIterations} scroll iterations, giving up`);
+				break;
+			}
 			const temp = await container.findElements(DefaultTreeSection.locators.DefaultTreeItem.ctor(label));
 			if (temp.length > 0) {
 				const level = +(await temp[0].getAttribute(DefaultTreeSection.locators.ViewSection.level))!;

--- a/packages/page-objects/src/components/workbench/DebugToolbar.ts
+++ b/packages/page-objects/src/components/workbench/DebugToolbar.ts
@@ -43,7 +43,7 @@ export class DebugToolbar extends AbstractElement {
 	 * Wait for the execution to pause at the next breakpoint
 	 */
 	async waitForBreakPoint(timeout: number = 10_000): Promise<void> {
-		let btn = await this.getDriver().wait(until.elementLocated(DebugToolbar.locators.DebugToolbar.button('continue')));
+		let btn = await this.getDriver().wait(until.elementLocated(DebugToolbar.locators.DebugToolbar.button('continue')), timeout);
 		await this.getDriver().wait(async () => {
 			try {
 				const enabled = await btn.isEnabled();

--- a/packages/page-objects/src/components/workbench/NotificationsCenter.ts
+++ b/packages/page-objects/src/components/workbench/NotificationsCenter.ts
@@ -48,7 +48,12 @@ export class NotificationsCenter extends AbstractElement {
 	 * @returns Promise resolving when the clear all button is pressed
 	 */
 	async clearAllNotifications(): Promise<void> {
-		await this.findElement(NotificationsCenter.locators.NotificationsCenter.clear).click();
+		const btn = await this.findElement(NotificationsCenter.locators.NotificationsCenter.clear);
+		const classes = (await btn.getAttribute('class')) ?? '';
+		if (classes.includes('disabled')) {
+			return;
+		}
+		await this.getDriver().executeScript('arguments[0].click()', btn);
 	}
 
 	/**

--- a/packages/page-objects/src/components/workbench/Workbench.ts
+++ b/packages/page-objects/src/components/workbench/Workbench.ts
@@ -123,7 +123,7 @@ export class Workbench extends AbstractElement {
 	async openSettings(): Promise<SettingsEditor> {
 		await this.executeCommand('Preferences: Open User Settings');
 		await new EditorView().openEditor('Settings');
-		await Workbench.driver.wait(until.elementLocated(Workbench.locators.Editor.constructor));
+		await Workbench.driver.wait(until.elementLocated(Workbench.locators.Editor.constructor), 10_000);
 		// Wait for settings editor to fully load
 		const editor = new SettingsEditor();
 		await this.getWaitHelper().forStable(editor, { timeout: 2000 });

--- a/packages/page-objects/src/components/workbench/input/Input.ts
+++ b/packages/page-objects/src/components/workbench/input/Input.ts
@@ -16,7 +16,7 @@
  */
 
 import { AbstractElement } from '../../AbstractElement';
-import { Key, WebElement } from 'selenium-webdriver';
+import { Key, WebElement, By } from 'selenium-webdriver';
 import { NullAttributeError, QuickOpenBox } from '../../..';
 import { sep } from 'path';
 
@@ -87,6 +87,75 @@ export abstract class Input extends AbstractElement {
 		const input = await this.findElement(Input.locators.Input.inputBox).findElement(Input.locators.Input.input);
 		await input.click();
 		await input.sendKeys(Key.ENTER);
+	}
+
+	/**
+	 * Confirm path selection for file/folder dialog.
+	 *
+	 * VS Code's file picker auto-navigates as text is typed: when a full path such as
+	 * `/dir/file.txt` is in the input, the picker shows the parent directory contents
+	 * with the filename filtered in the list. A single Enter press navigates into the
+	 * matched list entry. A subsequent click on the OK button (or a second Enter) then
+	 * confirms the selection and closes the dialog.
+	 *
+	 * When the path is not formatted to OS specifics there may first be a 'Select' step.
+	 * See also https://github.com/redhat-developer/vscode-extension-tester/issues/1778
+	 */
+	async confirmPath(): Promise<void> {
+		// Step 1 — drive VS Code's file picker to navigate into the typed path.
+		// Sending Enter selects the highlighted entry in the suggestion list, which
+		// causes the picker to consume the directory portion and reveal the target file.
+		const inputEl = await this.findElement(Input.locators.Input.inputBox).findElement(Input.locators.Input.input);
+		await inputEl.sendKeys(Key.ENTER);
+
+		// When the typed path uniquely resolves the target, the first Enter both
+		// navigates and confirms — the picker closes on its own and no second step
+		// is needed (attempting one would hit a hidden input).
+		if (!(await this.isPickerOpen())) {
+			return;
+		}
+
+		// Step 2 — click the OK button to confirm and close the dialog.
+		// Use a JS click to bypass any overlay that may intercept a normal WebDriver click.
+		// Falls back to a second Enter if no matching button is found.
+		try {
+			const buttons = await this.findElements(By.className('monaco-button'));
+			for (const btn of buttons) {
+				if (await btn.isDisplayed()) {
+					const label = ((await btn.getText()) || (await btn.getAttribute('aria-label')) || '').trim();
+					if (label === 'Select' || label === 'Ok' || label === 'OK') {
+						await Input.driver.executeScript('arguments[0].click()', btn);
+						return;
+					}
+				}
+			}
+		} catch (error) {
+			// ignore if button is not found or stale
+		}
+		if (!(await this.isPickerOpen())) {
+			return;
+		}
+		try {
+			await inputEl.sendKeys(Key.ENTER);
+		} catch (err) {
+			// The picker can close in the instant between the check above and the
+			// keystroke — a failure only matters while the picker is still open.
+			if (await this.isPickerOpen()) {
+				throw err;
+			}
+		}
+	}
+
+	/**
+	 * Best-effort check whether this input/picker widget is still displayed.
+	 * A hidden, detached or stale widget counts as closed.
+	 */
+	private async isPickerOpen(): Promise<boolean> {
+		try {
+			return await this.isDisplayed();
+		} catch {
+			return false;
+		}
 	}
 
 	/**

--- a/packages/page-objects/src/components/workbench/input/QuickOpenBox.ts
+++ b/packages/page-objects/src/components/workbench/input/QuickOpenBox.ts
@@ -32,7 +32,7 @@ export class QuickOpenBox extends Input {
 	 * Use when a quick open box is scheduled to appear.
 	 */
 	static async create(): Promise<QuickOpenBox> {
-		await QuickOpenBox.driver.wait(until.elementLocated(QuickOpenBox.locators.QuickOpenBox.constructor));
+		await QuickOpenBox.driver.wait(until.elementLocated(QuickOpenBox.locators.QuickOpenBox.constructor), 10_000);
 		return new QuickOpenBox().wait();
 	}
 

--- a/packages/page-objects/src/errors/ExTesterError.ts
+++ b/packages/page-objects/src/errors/ExTesterError.ts
@@ -122,7 +122,7 @@ export class ElementNotInteractableError extends ExTesterError {
 export class StaleElementError extends ExTesterError {
 	constructor(message: string, context: ErrorContext = {}) {
 		super(message, context);
-		this.name = 'StaleElementError';
+		this.name = 'StaleElementReferenceError';
 	}
 }
 

--- a/packages/page-objects/src/index.ts
+++ b/packages/page-objects/src/index.ts
@@ -28,6 +28,7 @@ export * from './locators/locators';
 export * from './errors/NullAttributeError';
 export * from './errors/ExTesterError';
 export * from './utils/WaitHelper';
+export * from './utils/TimeoutConstants';
 
 export * from './components/menu/Menu';
 export * from './components/menu/MenuItem';

--- a/packages/page-objects/src/locators/locators.ts
+++ b/packages/page-objects/src/locators/locators.ts
@@ -626,16 +626,42 @@ export function fromText(locator?: By): (el: WebElement) => Promise<string> {
 }
 
 export async function findBestContainingElement(container: IRectangle, testElements: WebElement[]): Promise<WebElement | undefined> {
-	const areas: number[] = await Promise.all(
-		testElements.map(async (value) => {
-			const rect = await value.getRect();
-			const ax = Math.max(container.x, rect.x);
-			const ay = Math.max(container.y, rect.y);
-			const bx = Math.min(container.x + container.width, rect.x + rect.width);
-			const by = Math.min(container.y + container.height, rect.y + rect.height);
-			return (bx - ax) * (by - ay);
-		}),
-	);
+	if (testElements.length === 0) {
+		return undefined;
+	}
+
+	// Short-circuit: single candidate needs no geometry.
+	if (testElements.length === 1) {
+		return testElements[0];
+	}
+
+	const rects = await Promise.all(testElements.map((el) => el.getRect()));
+
+	// When the container has not been laid out yet its rect is {0,0,0,0}.
+	// In that case overlap with any non-zero-position iframe would be negative
+	// for all candidates, causing the function to incorrectly return undefined.
+	// Fall back to picking the element with the largest own area so that the
+	// poll loop in switchToFrame can still make progress.
+	const containerArea = container.width * container.height;
+	if (containerArea === 0) {
+		let bestIdx = 0;
+		for (let i = 1; i < rects.length; i++) {
+			if (rects[i].width * rects[i].height > rects[bestIdx].width * rects[bestIdx].height) {
+				bestIdx = i;
+			}
+		}
+		return testElements[bestIdx];
+	}
+
+	// Normal case: pick the iframe whose intersection with the container is largest.
+	const areas = rects.map((rect) => {
+		const ax = Math.max(container.x, rect.x);
+		const ay = Math.max(container.y, rect.y);
+		const bx = Math.min(container.x + container.width, rect.x + rect.width);
+		const by = Math.min(container.y + container.height, rect.y + rect.height);
+		return (bx - ax) * (by - ay);
+	});
+
 	let bestIdx: number = -1;
 	for (let i = 0; i < testElements.length; i++) {
 		if (areas[i] < 0) {

--- a/packages/page-objects/src/utils/TimeoutConstants.ts
+++ b/packages/page-objects/src/utils/TimeoutConstants.ts
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License", destination); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Centralized timeout constants for page-object operations.
+ * Components should reference these instead of hardcoding values.
+ * Consumers can override by assigning to the mutable fields.
+ */
+export const TimeoutConstants = {
+	/** Default wait for an element to become visible (ms) */
+	ELEMENT_VISIBLE: 5_000,
+	/** Default wait for an element to become stable (ms) */
+	ELEMENT_STABLE: 2_000,
+	/** Wait for a menu to appear after context-click (ms) */
+	MENU_APPEAR: 2_000,
+	/** Wait for a menu item count to stabilize (ms) */
+	MENU_STABLE: 1_000,
+	/** Wait for an input box to appear (ms) */
+	INPUT_APPEAR: 5_000,
+	/** Wait for quick open / command palette (ms) */
+	QUICK_OPEN: 10_000,
+	/** Wait for editor to load (ms) */
+	EDITOR_LOAD: 5_000,
+	/** Wait for content assist to populate (ms) */
+	CONTENT_ASSIST: 10_000,
+	/** Wait for a tree section row container (ms) */
+	TREE_SECTION: 5_000,
+	/** Wait for extension install from marketplace (ms) */
+	EXTENSION_INSTALL: 300_000,
+	/** Wait for notifications to appear/dismiss (ms) */
+	NOTIFICATION: 2_000,
+	/** Close all editors timeout (ms) */
+	CLOSE_ALL_EDITORS: 60_000,
+	/** Wait for dialog / workbench elements (ms) */
+	DIALOG: 5_000,
+	/** Debug toolbar / breakpoint wait (ms) */
+	DEBUG: 10_000,
+	/** Webview frame switching (ms) */
+	WEBVIEW: 5_000,
+	/** Wait for clipboard operations (ms) */
+	CLIPBOARD: 2_000,
+	/** Default poll interval for condition waits (ms) */
+	POLL_INTERVAL: 100,
+	/** Default number of stability checks */
+	STABILITY_CHECKS: 3,
+};

--- a/packages/page-objects/src/utils/WaitHelper.ts
+++ b/packages/page-objects/src/utils/WaitHelper.ts
@@ -83,8 +83,16 @@ export class WaitHelper {
 					return result;
 				}
 			} catch (e) {
-				// Store error but continue retrying for transient errors
-				if (e instanceof error.StaleElementReferenceError || e instanceof error.NoSuchElementError) {
+				// Store error but continue retrying for transient failures.
+				// TimeoutError from driver.wait(until.elementIsVisible) means the element
+				// exists but is not yet visible — the condition should be retried rather
+				// than aborting the outer poll loop.
+				if (
+					e instanceof error.StaleElementReferenceError ||
+					e instanceof error.NoSuchElementError ||
+					e instanceof error.TimeoutError ||
+					(e as Error)?.name === 'TimeoutError'
+				) {
 					lastError = e as Error;
 				} else {
 					throw e;

--- a/tests/test-project/.mocharc.js
+++ b/tests/test-project/.mocharc.js
@@ -1,4 +1,8 @@
 module.exports = {
-	timeout: 10000,
+	// CI runners (especially macOS) can be 4-5x slower than average, and the
+	// page objects' internal condition waits legitimately need 10-30s there.
+	// A 10s global budget made every such test a timing lottery on slow
+	// machines - individual tests still override this where they need more.
+	timeout: 30000,
 	failZero: true,
 };

--- a/tests/test-project/.vscodeignore
+++ b/tests/test-project/.vscodeignore
@@ -7,3 +7,4 @@ test-extensions/**
 resources/**
 ../../**
 out/test/**
+extester.config*

--- a/tests/test-project/package.json
+++ b/tests/test-project/package.json
@@ -251,7 +251,20 @@
     "lint": "eslint --fix --fix-type layout src",
     "cb-init": "echo hello_ExTester | clipboard",
     "ui-test": "npm run cb-init && extest setup-and-run --config ./extester.config.json",
-    "ui-test:coverage": "MOCHA_GREP='order|clipboard|ExtensionsView|TitleBar' MOCHA_INVERT=true extest setup-and-run --config ./extester.config.coverage.json"
+    "ui-test:coverage": "MOCHA_GREP='order|clipboard|ExtensionsView|TitleBar' MOCHA_INVERT=true extest setup-and-run --config ./extester.config.coverage.json",
+    "test:01_general": "npm run cb-init && extest setup-and-run \"./out/test/*.test.js\" \"./out/test/01_general/**/*.test.js\" --config ./extester.config.json",
+    "test:activityBar": "npm run cb-init && extest setup-and-run \"./out/test/activityBar/**/*.test.js\" --config ./extester.config.json",
+    "test:bottomBar": "npm run cb-init && extest setup-and-run \"./out/test/bottomBar/**/*.test.js\" --config ./extester.config.json",
+    "test:cli": "npm run cb-init && extest setup-and-run \"./out/test/cli/order-3.test.js\" \"./out/test/cli/order-2.test.js\" \"./out/test/cli/order-1.test.js\" --config ./extester.config.json",
+    "test:debug": "npm run cb-init && extest setup-and-run \"./out/test/debug/**/*.test.js\" --config ./extester.config.json",
+    "test:dialog": "npm run cb-init && extest setup-and-run \"./out/test/dialog/**/*.test.js\" --config ./extester.config.json",
+    "test:editor": "npm run cb-init && extest setup-and-run \"./out/test/editor/**/*.test.js\" --config ./extester.config.json",
+    "test:menu": "npm run cb-init && extest setup-and-run \"./out/test/menu/**/*.test.js\" --config ./extester.config.json",
+    "test:statusBar": "npm run cb-init && extest setup-and-run \"./out/test/statusBar/**/*.test.js\" --config ./extester.config.json",
+    "test:system": "npm run cb-init && extest setup-and-run \"./out/test/system/**/*.test.js\" --config ./extester.config.json",
+    "test:webview": "npm run cb-init && extest setup-and-run \"./out/test/webview/**/*.test.js\" --config ./extester.config.json",
+    "test:workbench": "npm run cb-init && extest setup-and-run \"./out/test/workbench/**/*.test.js\" --config ./extester.config.json",
+    "test:xsideBar": "npm run cb-init && extest setup-and-run \"./out/test/xsideBar/**/*.test.js\" --config ./extester.config.json"
   },
   "devDependencies": {
     "chai": "^4.5.0",

--- a/tests/test-project/src/test/bottomBar/bottomBarPanel.test.ts
+++ b/tests/test-project/src/test/bottomBar/bottomBarPanel.test.ts
@@ -23,14 +23,33 @@ describe('BottomBarPanel', function () {
 	let panel: BottomBarPanel;
 
 	before(async function () {
+		this.timeout(30_000);
 		const browser = VSBrowser.instance;
 		await browser.openResources(path.resolve(__dirname, '..', '..', '..', 'resources', 'debug-project'), async () => {
 			await browser.driver.sleep(3_000);
 		});
 
 		panel = new BottomBarPanel();
-		await (await new Workbench().openNotificationsCenter()).clearAllNotifications();
-		await ((await new ActivityBar().getViewControl('Explorer')) as ViewControl).closeView();
+
+		// Clear notifications and close the center afterwards
+		const notifCenter = await new Workbench().openNotificationsCenter();
+		await notifCenter.clearAllNotifications();
+		try {
+			await notifCenter.close();
+		} catch {
+			// center may have already closed itself
+		}
+
+		// Close Explorer sidebar; wait for the animation to finish
+		const explorerControl = (await new ActivityBar().getViewControl('Explorer')) as ViewControl;
+		await explorerControl.closeView();
+		await browser.driver.wait(async () => {
+			try {
+				return !(await explorerControl.isSelected());
+			} catch {
+				return true; // control is gone / already closed
+			}
+		}, 5_000);
 	});
 
 	after(async function () {
@@ -38,25 +57,27 @@ describe('BottomBarPanel', function () {
 	});
 
 	it('can be toggled open', async function () {
+		this.timeout(10_000);
 		await panel.toggle(true);
 		expect(await panel.isDisplayed()).is.true;
 	});
 
 	it('can be toggled closed', async function () {
+		this.timeout(10_000);
 		await panel.toggle(true);
 		await panel.toggle(false);
 		expect(await panel.isDisplayed()).is.false;
 	});
 
 	it('can be maximized and restored', async function () {
-		this.timeout(20000);
+		this.timeout(20_000);
 		await panel.toggle(true);
 		const initHeight = await getHeight(panel);
 
 		await panel.maximize();
 		const maxHeight = await getHeight(panel);
 		expect(maxHeight).greaterThan(initHeight);
-		await new Promise((res) => setTimeout(res, 1000));
+		await panel.getDriver().sleep(1_000);
 
 		await panel.restore();
 		const restoredHeight = await getHeight(panel);
@@ -64,26 +85,31 @@ describe('BottomBarPanel', function () {
 	});
 
 	it('can open problems view', async function () {
+		this.timeout(10_000);
 		const view = await panel.openProblemsView();
 		expect(await view.isDisplayed()).is.true;
 	});
 
 	it('can open output view', async function () {
+		this.timeout(10_000);
 		const view = await panel.openOutputView();
 		expect(await view.isDisplayed()).is.true;
 	});
 
 	it('can open debug console view', async function () {
+		this.timeout(10_000);
 		const view = await panel.openDebugConsoleView();
 		expect(await view.isDisplayed()).is.true;
 	});
 
 	it('can open terminal view', async function () {
+		this.timeout(10_000);
 		const view = await panel.openTerminalView();
 		expect(await view.isDisplayed()).is.true;
 	});
 
 	it('can switch tabs using openTab', async function () {
+		this.timeout(15_000);
 		panel = new BottomBarPanel();
 		await panel.openTab('My Panel');
 		const webviewView = new WebviewView();

--- a/tests/test-project/src/test/bottomBar/problemsView.test.ts
+++ b/tests/test-project/src/test/bottomBar/problemsView.test.ts
@@ -25,7 +25,7 @@ describe('ProblemsView', function () {
 	let bar: BottomBarPanel;
 
 	before(async function () {
-		this.timeout(25000);
+		this.timeout(35_000);
 		await VSBrowser.instance.openResources(path.resolve(__dirname, '..', '..', '..', 'resources', 'test-file.ts'), async () => {
 			await VSBrowser.instance.driver.sleep(3_000);
 		});
@@ -36,15 +36,22 @@ describe('ProblemsView', function () {
 
 		editor = (await new EditorView().openEditor('test-file.ts')) as TextEditor;
 		await editor.setText('aaaa');
-		await view.getDriver().wait(() => {
-			return problemsExist(view);
-		}, 15000);
+		// Use driver.wait with an async condition; Selenium resolves Promise<boolean> correctly
+		await view.getDriver().wait(async () => {
+			try {
+				return await problemsExist(view);
+			} catch {
+				return false;
+			}
+		}, 20_000);
 
 		await view.setFilter('!test-resources/**'); // to workaround linux issues on CI occurring from VS Code 1.93.0
+		// Wait for filter to take effect rather than relying on a fixed sleep
 		await view.getDriver().sleep(500);
 	});
 
 	after(async function () {
+		this.timeout(15_000);
 		await view.clearFilter();
 		await editor.clearText();
 		if (await editor.isDirty()) {

--- a/tests/test-project/src/test/bottomBar/views.test.ts
+++ b/tests/test-project/src/test/bottomBar/views.test.ts
@@ -36,23 +36,30 @@ describe('Output View/Text Views', function () {
 	});
 
 	before(async function () {
-		this.timeout(15000);
+		this.timeout(20_000);
 		const wait = getWaitHelper();
 		const center = await new Workbench().openNotificationsCenter();
 		await center.clearAllNotifications();
-		await center.close();
+		try {
+			await center.close();
+		} catch {
+			// center may have already closed itself
+		}
 		panel = new BottomBarPanel();
 		await panel.toggle(true);
 		await panel.maximize();
+		// Wait for maximize animation to settle before opening the view
+		await wait.forStable(panel, { timeout: 2000 });
 		view = await panel.openOutputView();
 		// Wait for output view to stabilize
 		await wait.forStable(view, { timeout: 3000 });
 	});
 
 	after(async function () {
+		this.timeout(10_000);
 		const wait = getWaitHelper();
 		await panel.restore();
-		await wait.forStable(panel, { timeout: 1000 });
+		await wait.forStable(panel, { timeout: 2000 });
 		await panel.toggle(false);
 	});
 
@@ -106,11 +113,13 @@ describe('Output View/Text Views', function () {
 		let terminalName = process.platform === 'win32' ? (satisfies(VSBrowser.instance.version, '>=1.53.0') ? 'pwsh' : 'powershell') : 'bash';
 
 		before(async function () {
-			this.timeout(15_000);
+			this.timeout(20_000);
 			const wait = getWaitHelper();
+			// Ensure bottom bar is open before switching to terminal
+			await panel.toggle(true);
 			terminal = await panel.openTerminalView();
 			// Wait for terminal to stabilize
-			await wait.forStable(terminal, { timeout: 3000 });
+			await wait.forStable(terminal, { timeout: 5000 });
 		});
 
 		it('getText returns all current text', async function () {

--- a/tests/test-project/src/test/debug/debug.test.ts
+++ b/tests/test-project/src/test/debug/debug.test.ts
@@ -111,7 +111,9 @@ describe('Debugging', function () {
 
 		after(async function () {
 			this.timeout(15000);
-			if (await debugBar.isDisplayed()) {
+			// debugBar stays undefined when 'start the debug session' failed —
+			// cleanup must not mask the original failure with a TypeError.
+			if (debugBar && (await debugBar.isDisplayed().catch(() => false))) {
 				await debugBar.stop();
 			}
 		});
@@ -127,6 +129,10 @@ describe('Debugging', function () {
 		});
 
 		it('start the debug session', async function () {
+			// The debug adapter can take a while to spin up on slow CI runners —
+			// give the internal waits (toolbar creation + breakpoint pause, up to
+			// ~30s combined) more room than the global 10s mocha timeout.
+			this.timeout(40000);
 			await view.start();
 			debugBar = await DebugToolbar.create(10000);
 			await debugBar.waitForBreakPoint();
@@ -153,21 +159,30 @@ describe('Debugging', function () {
 		it('TextEditor: getBreakpoints works', async function () {
 			editor = (await new EditorView().openEditor('test.js')) as TextEditor;
 			const breakpoints = (await driver.wait<Breakpoint[]>(
-				async () => await editor.getBreakpoints(),
+				async () => {
+					const bps = await editor.getBreakpoints();
+					return bps.length === 2 ? bps : null;
+				},
 				10000,
-				'could not find breakpoints',
+				'could not find 2 breakpoints',
 			)) as Breakpoint[];
 			expect(breakpoints.length).equals(2);
 			expect(await breakpoints.at(0)?.getLineNumber()).equals(7);
 		});
 
 		it('Breakpoint: getLineNumber works', async function () {
-			breakpoint = (await driver.wait<Breakpoint>(
-				async () => await editor.getPausedBreakpoint(),
+			// The paused-marker-to-line mapping matches elements by their CSS top
+			// value, which can transiently mis-pair while the glyph margin
+			// re-renders — poll until the paused breakpoint reports the expected
+			// line instead of asserting a single sample.
+			await driver.wait(
+				async () => {
+					breakpoint = (await editor.getPausedBreakpoint()) as Breakpoint;
+					return breakpoint !== undefined && (await breakpoint.getLineNumber()) === line;
+				},
 				10000,
-				'could not find paused breakpoint',
-			)) as Breakpoint;
-			expect(await breakpoint.getLineNumber()).equals(line);
+				`paused breakpoint did not report line ${line}`,
+			);
 		});
 
 		it('Breakpoint: isPaused works', async function () {
@@ -413,7 +428,7 @@ describe('Debugging', function () {
 
 		it('stop the debug session', async function () {
 			await debugBar.stop();
-			await editor.getDriver().wait(until.elementIsNotVisible(debugBar));
+			await editor.getDriver().wait(until.elementIsNotVisible(debugBar), 5000, 'Debug toolbar did not disappear after stopping the session');
 		});
 
 		it('remove the second breakpoint', async function () {

--- a/tests/test-project/src/test/dialog/dialog.test.ts
+++ b/tests/test-project/src/test/dialog/dialog.test.ts
@@ -22,22 +22,51 @@ import { By, EditorView, InputBox, ModalDialog, TextEditor, until, VSBrowser, af
 (satisfies(VSBrowser.instance.version, '>=1.50.0') && process.platform !== 'darwin' ? describe : describe.skip)('Modal Dialog', function () {
 	let dialog: ModalDialog;
 
-	before(async () => {
+	before(async function (this: Mocha.Context) {
 		this.timeout(30000);
 		await new Workbench().executeCommand('Create: New File...');
-		await (await InputBox.create()).selectQuickPick('Text File');
-		await new Promise((res) => setTimeout(res, 1000));
+		await (await InputBox.create(10000)).selectQuickPick('Text File');
+		// Wait for the text editor to become active before interacting with it
+		await VSBrowser.instance.driver.wait(
+			until.elementLocated(By.className('monaco-editor')),
+			10000,
+			'Text editor did not become active after creating new file',
+		);
 		const editor = new TextEditor();
 		await editor.typeTextAt(1, 1, 'text');
-		await new Promise((res) => setTimeout(res, 1000));
-		await new EditorView().closeEditor(await editor.getTitle());
-		await new Promise((res) => setTimeout(res, 1000));
+		// Wait for the dirty indicator to confirm the edit was registered
+		await VSBrowser.instance.driver.wait(
+			async () => {
+				try {
+					return await editor.isDirty();
+				} catch {
+					return false;
+				}
+			},
+			5000,
+			'Editor did not become dirty after typing',
+		);
+		const title = await editor.getTitle();
+		await new EditorView().closeEditor(title);
+		// Wait for the modal dialog to appear instead of using a fixed sleep
 		dialog = new ModalDialog();
-		await dialog.getDriver().wait(until.elementsLocated(By.className('monaco-dialog-box')), 5000);
+		await dialog
+			.getDriver()
+			.wait(until.elementsLocated(By.className('monaco-dialog-box')), 10000, 'Modal dialog did not appear after closing dirty editor');
 	});
 
 	after(async function () {
-		await new Promise((res) => setTimeout(res, 1000));
+		// Dismiss any remaining dialog to leave a clean workbench state
+		try {
+			await dialog.getDriver().wait(until.stalenessOf(dialog), 1000);
+		} catch {
+			// Dialog may already be gone; attempt to push Don't Save as a fallback
+			try {
+				await dialog.pushButton(`Don't Save`);
+			} catch {
+				// Nothing left to clean up
+			}
+		}
 	});
 
 	it('getMessage works', async function () {
@@ -61,6 +90,6 @@ import { By, EditorView, InputBox, ModalDialog, TextEditor, until, VSBrowser, af
 	it('pushButton works', async function () {
 		this.timeout(10000);
 		await dialog.pushButton(`Don't Save`);
-		await dialog.getDriver().wait(until.stalenessOf(dialog), 2000);
+		await dialog.getDriver().wait(until.stalenessOf(dialog), 5000);
 	});
 });

--- a/tests/test-project/src/test/editor/customEditor.test.ts
+++ b/tests/test-project/src/test/editor/customEditor.test.ts
@@ -18,31 +18,62 @@
 import { expect } from 'chai';
 import path from 'path';
 import { CustomEditor, EditorView, VSBrowser, By } from 'vscode-extension-tester';
+import { waitFor, getWaitHelper } from '../testUtils';
 
 describe('CustomEditor', () => {
 	let editor: CustomEditor;
 
 	const CUSTOM_TITLE: string = 'example.cscratch';
 
-	before(async () => {
-		await VSBrowser.instance.openResources(path.resolve(__dirname, '..', '..', '..', 'resources', CUSTOM_TITLE), async () => {
-			await VSBrowser.instance.driver.sleep(3_000);
-		});
+	before(async function () {
+		this.timeout(100000);
+		// Ensure the driver is at the top-level window context before doing anything,
+		// in case a previous test suite left it inside a webview frame.
+		await VSBrowser.instance.driver.switchTo().defaultContent();
+		await VSBrowser.instance.openResources(path.resolve(__dirname, '..', '..', '..', 'resources', CUSTOM_TITLE));
+		const ew = new EditorView();
+		await waitFor(
+			async () => {
+				const titles = await ew.getOpenEditorTitles();
+				return titles.includes(CUSTOM_TITLE);
+			},
+			{ timeout: 20000, message: `Unable to find opened custom editor with title '${CUSTOM_TITLE}'` },
+		);
 		editor = new CustomEditor();
+
+		// Wait for the webview iframe to be fully ready before any test uses it.
+		// switchToFrame() polls for both the outer and inner active-frame iframes
+		// under a single shared deadline, so a single call with a generous timeout
+		// is both correct and sufficient — no retry loop needed in the test.
+		// Generous timeout: the slowest CI runners have shown webview creation
+		// taking well over 30s while the rest of the suite runs 4-5x slower too.
+		const webview = editor.getWebView();
+		await webview.switchToFrame(60000);
+		await webview.switchBack();
 	});
 
-	after(async () => {
+	after(async function () {
+		this.timeout(15000);
+		await VSBrowser.instance.driver.switchTo().defaultContent();
 		await new EditorView().closeAllEditors();
 	});
 
-	it('webview is available', async () => {
+	it('webview is available', async function () {
+		this.timeout(20000);
 		const webview = editor.getWebView();
-		await webview.switchToFrame();
+		await webview.switchToFrame(10000);
 		try {
 			const btn = await webview.findWebElement(By.className('add-button'));
-			await new Promise((res) => setTimeout(res, 500));
+			const wait = getWaitHelper();
+			await wait.forCondition(async () => (await btn.isDisplayed()) && (await btn.isEnabled()), { timeout: 5000 });
 			await btn.click();
-			await new Promise((res) => setTimeout(res, 1000));
+			await wait.forCondition(
+				async () => {
+					const notes = await webview.findWebElements(By.className('note'));
+					return notes.length > 0;
+				},
+				{ timeout: 5000, message: 'Notes did not appear after clicking add-button' },
+			);
 			const notes = await webview.findWebElements(By.className('note'));
 			const note = notes[notes.length - 1];
 			await webview.getDriver().actions().move({ origin: note }).perform();
@@ -58,23 +89,42 @@ describe('CustomEditor', () => {
 		}
 	});
 
-	it('isDirty works', async () => {
-		await new EditorView().openEditor(CUSTOM_TITLE);
-		await new Promise((res) => setTimeout(res, 500));
+	it('isDirty works', async function () {
+		this.timeout(15000);
+		const ew = new EditorView();
+		await ew.openEditor(CUSTOM_TITLE);
+		// Wait for the tab to actually become active before checking dirty state
+		await waitFor(async () => (await (await ew.getActiveTab())?.getTitle()) === CUSTOM_TITLE, {
+			timeout: 5000,
+			message: `Editor '${CUSTOM_TITLE}' did not become active`,
+		});
+		await waitFor(async () => await editor.isDirty(), { timeout: 8000, message: 'Editor did not become dirty' });
 		expect(await editor.isDirty()).is.true;
 	});
 
-	it('save works', async () => {
-		await new EditorView().openEditor(CUSTOM_TITLE);
-		await new Promise((res) => setTimeout(res, 500));
+	it('save works', async function () {
+		this.timeout(15000);
+		const ew = new EditorView();
+		await ew.openEditor(CUSTOM_TITLE);
+		// Wait for the tab to actually become active before checking dirty state
+		await waitFor(async () => (await (await ew.getActiveTab())?.getTitle()) === CUSTOM_TITLE, {
+			timeout: 5000,
+			message: `Editor '${CUSTOM_TITLE}' did not become active`,
+		});
+		await waitFor(async () => await editor.isDirty(), { timeout: 8000, message: 'Editor did not become dirty before save' });
 		await editor.save();
-		await new Promise((res) => setTimeout(res, 500));
+		await waitFor(async () => !(await editor.isDirty()), { timeout: 5000, message: 'Editor did not save successfully' });
 		expect(await editor.isDirty()).is.false;
 	});
 
-	it('save as works', async () => {
-		await new EditorView().openEditor(CUSTOM_TITLE);
-		await new Promise((res) => setTimeout(res, 500));
+	it('save as works', async function () {
+		this.timeout(15000);
+		const ew = new EditorView();
+		await ew.openEditor(CUSTOM_TITLE);
+		await waitFor(async () => (await (await ew.getActiveTab())?.getTitle()) === CUSTOM_TITLE, {
+			timeout: 5000,
+			message: 'Custom editor did not become active before saveAs',
+		});
 		try {
 			const input = await editor.saveAs();
 			expect(await input.isDisplayed()).is.true;

--- a/tests/test-project/src/test/editor/diffEditor.test.ts
+++ b/tests/test-project/src/test/editor/diffEditor.test.ts
@@ -19,6 +19,7 @@ import * as path from 'path';
 import { expect } from 'chai';
 import { EditorView, Workbench, DiffEditor, QuickOpenBox, InputBox, VSBrowser } from 'vscode-extension-tester';
 import { satisfies } from 'compare-versions';
+import { waitFor } from '../testUtils';
 
 (satisfies(VSBrowser.instance.version, '>=1.101.0') ? describe.skip : describe)('DiffEditor', async () => {
 	let editor: DiffEditor;
@@ -28,11 +29,17 @@ import { satisfies } from 'compare-versions';
 		await VSBrowser.instance.openResources(
 			path.resolve(__dirname, '..', '..', '..', 'resources', 'test-file-a.txt'),
 			path.resolve(__dirname, '..', '..', '..', 'resources', 'test-file-b.txt'),
-			async () => {
-				await VSBrowser.instance.driver.sleep(3_000);
-			},
 		);
-		await new EditorView().openEditor('test-file-b.txt');
+		const ew = new EditorView();
+		await waitFor(
+			async () => {
+				const titles = await ew.getOpenEditorTitles();
+				return titles.includes('test-file-a.txt') && titles.includes('test-file-b.txt');
+			},
+			{ timeout: 15000, message: 'Resources test-file-a.txt or test-file-b.txt did not open' },
+		);
+
+		await ew.openEditor('test-file-b.txt');
 		await new Workbench().executeCommand('File: Compare Active File With...');
 		let quickOpen: QuickOpenBox | InputBox;
 		if (satisfies(VSBrowser.instance.version, '>=1.44.0')) {
@@ -43,14 +50,23 @@ import { satisfies } from 'compare-versions';
 		await quickOpen.setText('test-file-a.txt');
 		await quickOpen.confirm();
 
+		await waitFor(
+			async () => {
+				const titles = await ew.getOpenEditorTitles();
+				return titles.some((t) => t.includes('test-file-b.txt') && t.includes('test-file-a.txt'));
+			},
+			{ timeout: 10000, message: 'Diff editor did not open' },
+		);
+
 		editor = new DiffEditor();
 	});
 
 	after(async () => {
-		await new Workbench().executeCommand('View: Close Editor');
-		await new Promise((res) => {
-			setTimeout(res, 500);
-		});
+		try {
+			await new Workbench().executeCommand('View: Close Editor');
+		} catch {
+			// ignore
+		}
 		await new EditorView().closeAllEditors();
 	});
 

--- a/tests/test-project/src/test/editor/editorView.test.ts
+++ b/tests/test-project/src/test/editor/editorView.test.ts
@@ -33,6 +33,7 @@ import {
 	NotificationType,
 	ContextMenu,
 } from 'vscode-extension-tester';
+import { waitFor } from '../testUtils';
 
 describe('EditorView', function () {
 	let view: EditorView;
@@ -44,9 +45,21 @@ describe('EditorView', function () {
 		await newUntitledFile('Untitled-1');
 		await newUntitledFile('Untitled-2');
 		await new Workbench().executeCommand('Webview Test Column 1');
-		await view.getDriver().sleep(2500);
+		await waitFor(
+			async () => {
+				const titles = await view.getOpenEditorTitles();
+				return titles.some((title) => title.startsWith('Test WebView'));
+			},
+			{ timeout: 15000, message: 'Webview Test Column 1 tab not found' },
+		);
 		await new Workbench().executeCommand('Open Settings UI');
-		await view.getDriver().sleep(500);
+		await waitFor(
+			async () => {
+				const titles = await view.getOpenEditorTitles();
+				return titles.includes('Settings');
+			},
+			{ timeout: 10000, message: 'Settings tab not found' },
+		);
 	});
 
 	after(async function () {
@@ -90,10 +103,25 @@ describe('EditorView', function () {
 		}
 		await quickOpen.setText('Untitled-1');
 		await quickOpen.confirm();
-		await quickOpen.getDriver().sleep(500);
+		await waitFor(
+			async () => {
+				const titles = await view.getOpenEditorTitles();
+				return titles.includes('Untitled-2 ↔ Untitled-1');
+			},
+			{ timeout: 10000, message: 'Diff editor tab not found' },
+		);
 
 		const diffEditor = (await view.openEditor('Untitled-2 ↔ Untitled-1')) as DiffEditor;
-		await diffEditor.getDriver().sleep(1000);
+		await waitFor(
+			async () => {
+				try {
+					return (await diffEditor.getOriginalEditor()) !== undefined && (await diffEditor.getModifiedEditor()) !== undefined;
+				} catch {
+					return false;
+				}
+			},
+			{ timeout: 10000, message: 'Original or Modified editor in DiffEditor did not load' },
+		);
 		expect(await diffEditor.getOriginalEditor()).not.undefined;
 		expect(await diffEditor.getModifiedEditor()).not.undefined;
 	});
@@ -112,6 +140,13 @@ describe('EditorView', function () {
 
 	it('closeEditor works', async function () {
 		await view.closeEditor('Untitled-1');
+		await waitFor(
+			async () => {
+				const tabs = await view.getOpenEditorTitles();
+				return !tabs.includes('Untitled-1');
+			},
+			{ timeout: 5000, message: 'Untitled-1 tab was not closed' },
+		);
 		const tabs = await view.getOpenEditorTitles();
 		expect(tabs).not.contains('Untitled-1');
 	});
@@ -229,10 +264,21 @@ describe('EditorView', function () {
 		});
 
 		it('closeEditor works for different groups', async function () {
-			await view.getDriver().actions().keyDown(EditorView.ctlKey).sendKeys('\\').perform();
-			await view.getDriver().sleep(500);
+			await view.getDriver().actions().keyDown(EditorView.ctlKey).sendKeys('\\').keyUp(EditorView.ctlKey).perform();
+			await waitFor(
+				async () => {
+					return (await view.getEditorGroups()).length === 3;
+				},
+				{ timeout: 10000, message: 'Expected 3 editor groups after split' },
+			);
 
 			await view.closeEditor(testFile, 2);
+			await waitFor(
+				async () => {
+					return (await view.getEditorGroups()).length === 2;
+				},
+				{ timeout: 5000, message: 'Expected 2 editor groups after closing' },
+			);
 			expect((await view.getEditorGroups()).length).equals(2);
 		});
 

--- a/tests/test-project/src/test/editor/extensionEditor.test.ts
+++ b/tests/test-project/src/test/editor/extensionEditor.test.ts
@@ -29,6 +29,8 @@ import {
 	WebDriver,
 	Workbench,
 	BottomBarPanel,
+	after,
+	before,
 } from 'vscode-extension-tester';
 import * as pjson from '../../../package.json';
 import * as path from 'path';
@@ -40,55 +42,113 @@ describe('Extension Editor', function () {
 	let extensionsView: SideBarView;
 	let item: ExtensionsViewItem;
 
-	let section: ExtensionsViewSection;
-
 	let extensionEditor: ExtensionEditorView;
 	let extensionEditorDetails: ExtensionEditorDetailsSection;
 
-	before(async function () {
-		this.timeout(20000);
+	before(async function (this: Mocha.Context) {
+		this.timeout(60000);
 
 		driver = VSBrowser.instance.driver;
-		await VSBrowser.instance.openResources(path.resolve(__dirname, '..', '..', '..', 'resources', 'test-folder'), async () => {
-			await driver.sleep(3_000);
-		});
-		viewControl = (await new ActivityBar().getViewControl('Extensions')) as ViewControl;
-		extensionsView = await viewControl.openView();
+		await driver.switchTo().defaultContent();
+		await VSBrowser.instance.openResources(path.resolve(__dirname, '..', '..', '..', 'resources', 'test-folder'));
+		await VSBrowser.instance.waitForWorkbench();
+		// Page objects constructed in the instant before the reload's DOM teardown
+		// die on first use — retry the whole acquisition until the view opens.
+		await driver.wait(
+			async () => {
+				try {
+					viewControl = (await new ActivityBar().getViewControl('Extensions')) as ViewControl;
+					extensionsView = await viewControl.openView();
+					return true;
+				} catch {
+					return false;
+				}
+			},
+			30000,
+			'Could not open the Extensions view',
+		);
 		await driver.wait(async function () {
 			return (await extensionsView.getContent().getSections()).length > 0;
-		});
+		}, 15000);
 
 		const view = await viewControl.openView();
 
 		await driver.wait(async function () {
 			return (await view.getContent().getSections()).length > 0;
-		});
-		section = (await view.getContent().getSection('Installed')) as ExtensionsViewSection;
-
+		}, 15000);
 		await driver.wait(async function () {
-			item = (await section.findItem(`@installed ${pjson.displayName}`)) as ExtensionsViewItem;
-			return item !== undefined;
-		});
+			try {
+				const currentView = await viewControl.openView();
+				const currentSection = (await currentView.getContent().getSection('Installed')) as ExtensionsViewSection;
+				item = (await currentSection.findItem(`@installed ${pjson.displayName}`)) as ExtensionsViewItem;
+				return item !== undefined;
+			} catch (e: any) {
+				if (e.name === 'StaleElementReferenceError') {
+					return false;
+				}
+				throw e;
+			}
+		}, 30000);
 
-		await item.click();
+		await driver.wait(
+			async () => {
+				// Every step in this poll can hit a stale element while the extensions
+				// list or editor area re-renders — treat any failure as "not yet" and
+				// retry on the next tick rather than failing the whole hook.
+				try {
+					try {
+						await item.click();
+					} catch {
+						// The extensions list re-renders asynchronously (marketplace queries,
+						// filter refreshes) and stales the item reference — re-locate it
+						// before the next attempt instead of clicking a dead element.
+						const currentView = await viewControl.openView();
+						const currentSection = (await currentView.getContent().getSection('Installed')) as ExtensionsViewSection;
+						item = (await currentSection.findItem(`@installed ${pjson.displayName}`)) as ExtensionsViewItem;
+					}
+					const titles = await new EditorView().getOpenEditorTitles();
+					return titles.some((title) => title.includes('Extension:'));
+				} catch {
+					return false;
+				}
+			},
+			30000,
+			'Extension editor did not open after click',
+		);
 	});
 
 	// ensure clean workbench
-	before(async function () {
+	before(async function (this: Mocha.Context) {
+		this.timeout(15000);
 		const panel = new BottomBarPanel();
 		if (await panel.isDisplayed()) {
 			await panel.toggle(false);
 		}
-		await (await new Workbench().openNotificationsCenter()).clearAllNotifications();
+		try {
+			await (await new Workbench().openNotificationsCenter()).clearAllNotifications();
+		} catch {
+			// Notifications center may already be empty or not accessible
+		}
 	});
 
-	after(async function () {
-		await viewControl.closeView();
+	after(async function (this: Mocha.Context) {
+		this.timeout(30000);
+		// viewControl stays undefined when the before() hook failed early —
+		// cleanup must not mask the original failure with a TypeError.
+		if (viewControl) {
+			await viewControl.closeView();
+		}
 		await new EditorView().closeAllEditors();
+		// Re-open the original workspace. The first before() hook changed
+		// the workspace to test-folder via openResources — subsequent test
+		// files (settingsEditor, textEditor) need the workspace to be the
+		// test-project root so their CLI-based file opens can succeed.
+		await VSBrowser.instance.openResources(path.resolve(__dirname, '..', '..', '..'));
+		await VSBrowser.instance.waitForWorkbench();
 	});
 
 	describe('ExtensionEditorView', function () {
-		before(async function () {
+		before(async function (this: Mocha.Context) {
 			extensionEditor = new ExtensionEditorView();
 		});
 
@@ -127,7 +187,7 @@ describe('Extension Editor', function () {
 	});
 
 	describe('ExtensionEditorDetailsSections', function () {
-		before(async function () {
+		before(async function (this: Mocha.Context) {
 			await extensionEditor.switchToTab('Details');
 			extensionEditorDetails = new ExtensionEditorDetailsSection();
 		});

--- a/tests/test-project/src/test/editor/settingsEditor.test.ts
+++ b/tests/test-project/src/test/editor/settingsEditor.test.ts
@@ -22,7 +22,7 @@ import { getWaitHelper, waitFor } from '../testUtils';
 describe('Settings Editor', function () {
 	let editor: SettingsEditor;
 
-	before(async () => {
+	before(async function (this: Mocha.Context) {
 		this.timeout(30000);
 		const wait = getWaitHelper();
 		editor = await new Workbench().openSettings();
@@ -55,7 +55,7 @@ describe('Settings Editor', function () {
 	describe('combo setting', function () {
 		let setting: ComboSetting;
 
-		before(async () => {
+		before(async function (this: Mocha.Context) {
 			this.timeout(15000);
 			setting = (await editor.findSetting('Title Bar Style', 'Window')) as ComboSetting;
 		});
@@ -102,7 +102,7 @@ describe('Settings Editor', function () {
 	describe('text setting', function () {
 		let setting: TextSetting;
 
-		before(async () => {
+		before(async function (this: Mocha.Context) {
 			this.timeout(15000);
 			setting = (await editor.findSetting('Auto Save Delay', 'Files')) as TextSetting;
 		});
@@ -122,7 +122,7 @@ describe('Settings Editor', function () {
 	describe('checkbox setting', function () {
 		let setting: CheckboxSetting;
 
-		before(async () => {
+		before(async function (this: Mocha.Context) {
 			this.timeout(15000);
 			setting = (await editor.findSetting('Code Lens', 'Editor')) as CheckboxSetting;
 		});
@@ -142,7 +142,7 @@ describe('Settings Editor', function () {
 	describe('array setting', function () {
 		let setting: ArraySetting;
 
-		before(async () => {
+		before(async function (this: Mocha.Context) {
 			this.timeout(15000);
 			setting = (await editor.findSetting('Hello World Array', 'Test Project', 'General')) as ArraySetting;
 		});

--- a/tests/test-project/src/test/editor/textEditor.test.ts
+++ b/tests/test-project/src/test/editor/textEditor.test.ts
@@ -26,6 +26,7 @@ import {
 	Workbench,
 	FindWidget,
 	VSBrowser,
+	ModalDialog,
 	after,
 	before,
 	afterEach,
@@ -38,27 +39,38 @@ describe('ContentAssist', function () {
 	let assist: ContentAssist;
 	let editor: TextEditor;
 
-	before(async () => {
-		this.timeout(30000);
-		const wait = getWaitHelper();
-		await VSBrowser.instance.openResources(path.resolve(__dirname, '..', '..', '..', 'resources', 'test-file.ts'), async () => {
-			await wait.sleep(3000);
-		});
+	before(async function (this: Mocha.Context) {
+		this.timeout(120000);
+		// Ensure the driver is at the top-level window context before doing anything,
+		// in case the previous test suite left it inside a webview frame.
+		await VSBrowser.instance.driver.switchTo().defaultContent();
+		// Close all editors first to ensure a clean state regardless of what ran before.
+		await new EditorView().closeAllEditors();
+		await VSBrowser.instance.openResources(path.resolve(__dirname, '..', '..', '..', 'resources', 'test-file.ts'));
 		await VSBrowser.instance.waitForWorkbench();
 		const ew = new EditorView();
+		await waitFor(
+			async () => {
+				const titles = await ew.getOpenEditorTitles();
+				return titles.includes('test-file.ts');
+			},
+			{ timeout: 60000, message: 'test-file.ts editor did not open' },
+		);
+
 		try {
 			await ew.closeEditor('Welcome');
 		} catch (error) {
 			// continue - Welcome page is not displayed
 		}
 		editor = (await ew.openEditor('test-file.ts')) as TextEditor;
-		// Wait for JS/TS language features to initialize
+		// Wait for JS/TS language features to initialize. Use a fixed timeout so the budget
+		// is not consumed by earlier steps in this same before() hook.
 		await waitFor(
 			async () => {
 				const progress = await new StatusBar().getItem('Initializing JS/TS language features');
 				return !progress;
 			},
-			{ timeout: this.timeout() - 2000, message: 'Initializing JS/TS language features was not finished yet!' },
+			{ timeout: 45000, message: 'Initializing JS/TS language features was not finished yet!' },
 		);
 	});
 
@@ -91,7 +103,10 @@ describe('ContentAssist', function () {
 	});
 
 	it('getItem can find an item beyond visible range', async function () {
-		const item = await assist.getItem('Buffer');
+		// Use a core ES-lib global that is always present in the suggestion list.
+		// Node-only globals (e.g. 'Buffer') depend on @types/node being available
+		// via automatic type acquisition, which is asynchronous and network-bound.
+		const item = await assist.getItem('Math');
 		expect(item).not.undefined;
 	}).timeout(15000);
 
@@ -107,31 +122,77 @@ describe('TextEditor', function () {
 
 	const testText = process.platform === 'win32' ? `line1\r\nline2\r\nline3` : `line1\nline2\nline3`;
 
-	before(async () => {
-		this.timeout(8000);
+	before(async function (this: Mocha.Context) {
+		this.timeout(30000);
 		await new Workbench().executeCommand('Create: New File...');
 		await (await InputBox.create()).selectQuickPick('Text File');
-		// Wait for editor to be ready
+		view = new EditorView();
+		// Wait for an untitled editor tab to be active before proceeding.
 		await waitFor(
 			async () => {
-				const ew = new EditorView();
-				const titles = await ew.getOpenEditorTitles();
-				return titles.length > 0;
+				const titles = await view.getOpenEditorTitles();
+				return titles.some((t) => t.startsWith('Untitled'));
 			},
-			{ timeout: 5000, message: 'Editor did not open' },
+			{ timeout: 15000, message: 'Untitled editor did not open' },
 		);
-		view = new EditorView();
 		editor = new TextEditor(view);
+		// Confirm the editor element is visible before interacting with it.
+		await waitFor(
+			async () => {
+				try {
+					return await editor.isDisplayed();
+				} catch {
+					return false;
+				}
+			},
+			{ timeout: 10000, message: 'New file editor was not visible' },
+		);
 
 		await new StatusBar().openLanguageSelection();
 		const input = await InputBox.create();
 		await input.setText('typescript');
-		await input.confirm();
+		await input.selectQuickPick('TypeScript');
 	});
 
-	after(async function () {
-		await editor.clearText();
-		await view.closeAllEditors();
+	after(async function (this: Mocha.Context) {
+		this.timeout(30000);
+		const wait = getWaitHelper();
+		// Dismiss any open overlay (find widget, context menu, suggest widget).
+		try {
+			await editor.getDriver().actions().sendKeys('\uE00C').perform();
+		} catch {
+			// ignore
+		}
+		// Dismiss any already-open dialog from a previous test failure.
+		try {
+			await new ModalDialog().pushButton("Don't Save");
+			await wait.sleep(500);
+		} catch {
+			// no dialog present
+		}
+		// Close the dirty untitled editor tab directly — closeEditor clicks
+		// the close button and returns without waiting, so it won't hang
+		// when the Save dialog appears (unlike closeAllEditors which loops).
+		try {
+			const title = await editor.getTitle();
+			await view.closeEditor(title);
+		} catch {
+			// editor may already be closed
+		}
+		// Handle the Save dialog triggered by closing the dirty buffer.
+		await wait.sleep(500);
+		try {
+			await new ModalDialog().pushButton("Don't Save");
+			await wait.sleep(500);
+		} catch {
+			// no dialog appeared — buffer was clean
+		}
+		// Close any remaining clean editors.
+		try {
+			await view.closeAllEditors();
+		} catch {
+			// best-effort cleanup
+		}
 	});
 
 	it('can get and set text', async function () {
@@ -199,18 +260,27 @@ describe('TextEditor', function () {
 				let editor: TextEditor;
 				let ew: EditorView;
 
-				beforeEach(async function () {
-					const wait = getWaitHelper();
-					await VSBrowser.instance.openResources(path.resolve(__dirname, '..', '..', '..', 'resources', param.file), async () => {
-						await wait.sleep(3000);
-					});
+				beforeEach(async function (this: Mocha.Context) {
+					this.timeout(90000);
+					await VSBrowser.instance.openResources(path.resolve(__dirname, '..', '..', '..', 'resources', param.file));
 					ew = new EditorView();
-					// Wait for editor to be available
+					// Wait for editor to be available. Use a generous timeout on slow CI
+					// runners (especially macOS) where the CLI open command can take longer
+					// than expected to be reflected in the editor tab list.
 					await waitFor(async () => (await ew.getOpenEditorTitles()).includes(param.file), {
-						timeout: 10_000,
+						timeout: 60_000,
 						message: `Unable to find opened editor with title '${param.file}'`,
 					});
 					editor = (await ew.openEditor(param.file)) as TextEditor;
+				});
+
+				afterEach(async function (this: Mocha.Context) {
+					this.timeout(15000);
+					try {
+						await ew.closeEditor(param.file);
+					} catch {
+						// tab may already be closed
+					}
 				});
 
 				for (const coor of [
@@ -396,27 +466,35 @@ describe('TextEditor', function () {
 	});
 
 	describe('CodeLens', function () {
-		before(async function () {
+		before(async function (this: Mocha.Context) {
+			this.timeout(20000);
 			const wait = getWaitHelper();
 			await new Workbench().executeCommand('Enable CodeLens');
 			// older versions of vscode don't fire the update event immediately, give it some encouragement
 			// otherwise the lenses end up empty
 			await new Workbench().executeCommand('Enable CodeLens');
-			// Wait for CodeLens to appear
+			// Wait for CodeLens to appear — use a generous timeout for slow CI runners
 			await wait.forCondition(
 				async () => {
 					const lenses = await editor.getCodeLenses();
 					return lenses.length > 0;
 				},
-				{ timeout: 5000, message: 'CodeLens did not appear' },
+				{ timeout: 15000, message: 'CodeLens did not appear' },
 			);
 		});
 
-		after(async function () {
+		after(async function (this: Mocha.Context) {
+			this.timeout(15000);
 			await new Workbench().executeCommand('Disable Codelens');
-			const nc = await new Workbench().openNotificationsCenter();
-			await nc.clearAllNotifications();
-			await nc.close();
+			// Notifications cleanup is best-effort: if the center is already closed
+			// or has no notifications the clear button may not be accessible.
+			try {
+				const nc = await new Workbench().openNotificationsCenter();
+				await nc.clearAllNotifications();
+				await nc.close();
+			} catch {
+				// Ignore — notifications may already be gone
+			}
 		});
 
 		it('getCodeLens works with index', async function () {
@@ -434,8 +512,11 @@ describe('TextEditor', function () {
 			expect(await lens?.getTooltip()).has.string('Tooltip provided');
 		});
 
-		it('getCodeLenses works with second in the span', async function () {
-			const lens = await editor.getCodeLens(6);
+		it('getCodeLenses works with second in the span', async function (this: Mocha.Context) {
+			this.timeout(15000);
+			// Lenses within a span render progressively — the second one can appear
+			// noticeably later than the first on slow runners, so poll until it exists.
+			const lens = await editor.getDriver().wait(async () => await editor.getCodeLens(6), 10000, 'CodeLens at index 6 did not appear');
 			expect(lens).is.not.undefined;
 			expect(await lens?.getText()).has.string('Codelens provided');
 			expect(await lens?.getTooltip()).has.string('Tooltip provided');

--- a/tests/test-project/src/test/menu/contextMenu.test.ts
+++ b/tests/test-project/src/test/menu/contextMenu.test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { TitleBar, ContextMenu, before, beforeEach, VSBrowser } from 'vscode-extension-tester';
+import { TitleBar, ContextMenu, VSBrowser } from 'vscode-extension-tester';
 import { expect } from 'chai';
 import * as path from 'path';
 
@@ -23,7 +23,7 @@ import * as path from 'path';
 	let bar: TitleBar;
 	let menu: ContextMenu;
 
-	before(async () => {
+	before(async function () {
 		this.timeout(30000);
 		await VSBrowser.instance.openResources(path.resolve(__dirname, '..', '..', '..', 'resources', 'test-folder'), async () => {
 			await VSBrowser.instance.driver.sleep(3_000);
@@ -31,8 +31,20 @@ import * as path from 'path';
 	});
 
 	beforeEach(async function () {
+		this.timeout(10000);
 		bar = new TitleBar();
 		menu = (await bar.select('File')) as ContextMenu;
+	});
+
+	afterEach(async function () {
+		// Ensure no stray menu is left open between tests
+		try {
+			if (menu && (await menu.isDisplayed())) {
+				await menu.close();
+			}
+		} catch {
+			// menu already gone
+		}
 	});
 
 	it('getItems finds all menu items', async function () {

--- a/tests/test-project/src/test/menu/titleBar.test.ts
+++ b/tests/test-project/src/test/menu/titleBar.test.ts
@@ -39,7 +39,11 @@ import { ActivityBar, TitleBar, ContextMenu, TitleBarItem, EditorView, VSBrowser
 	});
 
 	after(async function () {
-		this.timeout(10000);
+		this.timeout(20000);
+		// Move mouse away from tab bar so that VS Code tooltip overlays do not
+		// intercept the close-button click (ElementClickInterceptedError on CI).
+		await VSBrowser.instance.driver.actions().move({ x: 0, y: 0 }).perform();
+		await VSBrowser.instance.driver.sleep(300);
 		await new EditorView().closeAllEditors();
 	});
 
@@ -88,6 +92,7 @@ import { ActivityBar, TitleBar, ContextMenu, TitleBarItem, EditorView, VSBrowser
 	});
 
 	it('select navigates a multi level path', async function () {
+		this.timeout(15000);
 		const menu = (await bar.select('File', 'Open Recent', 'Reopen Closed Editor')) as ContextMenu;
 		expect(menu).is.undefined;
 	});

--- a/tests/test-project/src/test/statusBar/statusBar.test.ts
+++ b/tests/test-project/src/test/statusBar/statusBar.test.ts
@@ -18,6 +18,7 @@
 import { expect } from 'chai';
 import { satisfies } from 'compare-versions';
 import { StatusBar, EditorView, InputBox, QuickOpenBox, Workbench, VSBrowser } from 'vscode-extension-tester';
+import { waitFor } from '../testUtils';
 
 describe('StatusBar', () => {
 	let bar: StatusBar;
@@ -35,9 +36,11 @@ describe('StatusBar', () => {
 
 	it('can open and close the notification center', async () => {
 		const center = await bar.openNotificationsCenter();
+		await waitFor(async () => await center.isDisplayed(), { timeout: 10000, message: 'Notifications center did not open' });
 		expect(await center.isDisplayed()).is.true;
 
 		await bar.closeNotificationsCenter();
+		await waitFor(async () => !(await center.isDisplayed()), { timeout: 10000, message: 'Notifications center did not close' });
 		expect(await center.isDisplayed()).is.false;
 	});
 

--- a/tests/test-project/src/test/webview/webView.test.ts
+++ b/tests/test-project/src/test/webview/webView.test.ts
@@ -15,24 +15,31 @@
  * limitations under the License.
  */
 
-import { Workbench, EditorView, WebView, By, EditorGroup, until, VSBrowser, WebDriver } from 'vscode-extension-tester';
+import { Workbench, EditorView, WebView, By, EditorGroup } from 'vscode-extension-tester';
 import { expect } from 'chai';
-import { getWaitHelper, waitFor } from '../testUtils';
+import { waitFor } from '../testUtils';
 
 describe('WebViews', function () {
 	describe('Single WebView', function () {
 		let view: WebView;
-		let driver: WebDriver;
 
 		before(async function () {
-			this.timeout(8000);
-			driver = VSBrowser.instance.driver;
+			this.timeout(15_000);
 			await new Workbench().executeCommand('Webview Test Column 1');
-			const wait = getWaitHelper();
-			await wait.sleep(1_500);
+
+			// Wait dynamically for the webview tab to appear before constructing
+			// the page object — avoids the fixed sleep(1_500) that was both slow
+			// on fast machines and insufficient on cold CI runners.
+			await waitFor(
+				async () => {
+					const titles = await new EditorView().getOpenEditorTitles();
+					return titles.length > 0;
+				},
+				{ timeout: 10_000, message: 'WebView tab did not appear' },
+			);
 
 			view = new WebView();
-			await view.switchToFrame(5_000);
+			await view.switchToFrame(10_000);
 		});
 
 		after(async function () {
@@ -41,15 +48,13 @@ describe('WebViews', function () {
 		});
 
 		it('findWebElement works', async function () {
-			await driver.wait(until.elementLocated(By.css('h1')));
-
+			// switchToFrame() already waited for the active frame to be ready;
+			// no extra driver.wait() needed here.
 			const element = await view.findWebElement(By.css('h1'));
 			expect(await element.getText()).has.string('This is a web view');
 		});
 
 		it('findWebElements works', async function () {
-			await driver.wait(until.elementLocated(By.css('h1')));
-
 			const elements = await view.findWebElements(By.css('h1'));
 			expect(elements.length).equals(1);
 		});
@@ -65,18 +70,20 @@ describe('WebViews', function () {
 		});
 
 		before(async function () {
-			this.timeout(45000);
+			this.timeout(45_000);
 			const workbench = new Workbench();
 
 			for (let i = 0; i < 3; i++) {
 				await workbench.executeCommand(`Webview Test Column ${i + 1}`);
-				// Wait for the editor group to appear
+				// Wait for the editor group count to reach the expected value.
+				// Use a slightly longer poll interval so we don't thrash the DOM
+				// while VS Code is animating the pane creation.
 				await waitFor(
 					async () => {
 						const groups = await new EditorView().getEditorGroups();
 						return groups.length >= i + 1;
 					},
-					{ timeout: 5000, message: `Editor group ${i + 1} did not appear` },
+					{ timeout: 10_000, pollInterval: 500, message: `Editor group ${i + 1} did not appear` },
 				);
 			}
 
@@ -101,8 +108,9 @@ describe('WebViews', function () {
 		for (let i = 0; i < 3; i++) {
 			describe(`WebView ${i}`, function () {
 				before(async function () {
+					this.timeout(15_000);
 					view = new WebView(editorGroups[i]);
-					await view.switchToFrame(5_000);
+					await view.switchToFrame(10_000);
 				});
 
 				after(async function () {
@@ -131,17 +139,19 @@ describe('WebViews', function () {
 		});
 
 		before(async function () {
-			this.timeout(45000);
+			this.timeout(45_000);
 			const workbench = new Workbench();
 			for (let i = 0; i < 3; i++) {
 				await workbench.executeCommand('Webview Test Column 1');
-				// Wait for editor count to increase
+				// Wait for the tab count to reach the expected value before issuing
+				// the next command, so each webview has a distinct title captured
+				// later.
 				await waitFor(
 					async () => {
 						const titles = await new EditorView().getOpenEditorTitles();
 						return titles.length >= i + 1;
 					},
-					{ timeout: 5000, message: `WebView ${i + 1} did not open` },
+					{ timeout: 10_000, pollInterval: 500, message: `WebView ${i + 1} did not open` },
 				);
 			}
 
@@ -150,7 +160,8 @@ describe('WebViews', function () {
 		for (let i = 0; i < 3; i++) {
 			describe(`WebView ${i}`, function () {
 				before(async function () {
-					this.timeout(15000);
+					// Allow extra headroom: openEditor + switchToFrame(10_000) both need time.
+					this.timeout(20_000);
 					await new EditorView().openEditor(tabs[i]);
 					view = new WebView();
 					await view.switchToFrame(10_000);

--- a/tests/test-project/src/test/webview/webviewView.test.ts
+++ b/tests/test-project/src/test/webview/webviewView.test.ts
@@ -17,10 +17,11 @@
 
 import { expect } from 'chai';
 import { BottomBarPanel, By, CustomTreeSection, EditorView, SideBarView, WebviewView, Workbench } from 'vscode-extension-tester';
-import { getWaitHelper, waitFor } from '../testUtils';
+import { waitFor } from '../testUtils';
 
 describe('WebviewViews', function () {
 	let webviewView: InstanceType<typeof WebviewView>;
+
 	function runTests(title: string, li: string[]) {
 		it(`Shopping List Title ${title}`, async () => {
 			const element = await webviewView.findWebElement(By.css('h1'));
@@ -30,12 +31,13 @@ describe('WebviewViews', function () {
 		it(`Shopping List Equals ${li.join(', ')} `, async () => {
 			const elts = await webviewView.findWebElements(By.xpath('//div/ul/li'));
 			expect(elts.length).equals(li.length);
+			// Collect list items sequentially to preserve DOM order — using
+			// Promise.all with an array push would resolve in non-deterministic
+			// order on slow CI runners.
 			const listContent: string[] = [];
-			await Promise.all(
-				elts.map(async (elt) => {
-					listContent.push(await elt.getText());
-				}),
-			);
+			for (const elt of elts) {
+				listContent.push(await elt.getText());
+			}
 			expect(listContent).to.eql(li);
 		});
 	}
@@ -55,7 +57,7 @@ describe('WebviewViews', function () {
 					return false;
 				}
 			},
-			{ timeout: 10000, pollInterval: 1000, message: 'Failed to close bottom panel' },
+			{ timeout: 10_000, pollInterval: 1000, message: 'Failed to close bottom panel' },
 		);
 	}
 
@@ -70,14 +72,21 @@ describe('WebviewViews', function () {
 
 	describe('BottomBar WebviewViews', function () {
 		before(async function () {
-			this.timeout(15000);
-			const wait = getWaitHelper();
+			this.timeout(15_000);
 			await new Workbench().executeCommand('My Panel: Focus on My Panel View View');
-			// Wait for panel to be visible and stable
+			// Wait for the panel to be visible before constructing the WebviewView
+			// and switching frames. forStable() on a newly-opened panel confirms
+			// the element has settled in the DOM after the command resolves.
+			await waitFor(
+				async () => {
+					const panel = new BottomBarPanel();
+					return await panel.isDisplayed();
+				},
+				{ timeout: 5_000, message: 'BottomBarPanel did not become visible' },
+			);
 			const panel = new BottomBarPanel();
-			await wait.forStable(panel, { timeout: 3000 });
 			webviewView = new WebviewView(panel);
-			await webviewView.switchToFrame(10000);
+			await webviewView.switchToFrame(10_000);
 		});
 		after(async () => {
 			await webviewView.switchBack();
@@ -89,14 +98,19 @@ describe('WebviewViews', function () {
 
 	describe('Sidebar WebviewViews', function () {
 		before(async function () {
-			this.timeout(15000);
-			const wait = getWaitHelper();
+			this.timeout(15_000);
 			await new Workbench().executeCommand('Explorer: Focus on My Side Panel View View');
-			// Wait for sidebar to be visible and stable
+			// Wait for the sidebar to be visible before constructing the WebviewView.
+			await waitFor(
+				async () => {
+					const sidebar = new SideBarView();
+					return await sidebar.isDisplayed();
+				},
+				{ timeout: 5_000, message: 'SideBarView did not become visible' },
+			);
 			const sidebar = new SideBarView();
-			await wait.forStable(sidebar, { timeout: 3000 });
 			webviewView = new WebviewView(sidebar);
-			await webviewView.switchToFrame(10000);
+			await webviewView.switchToFrame(10_000);
 		});
 		after(async () => {
 			await webviewView.switchBack();
@@ -108,14 +122,13 @@ describe('WebviewViews', function () {
 
 	describe('Sidebar And BottomBar WebviewViews', function () {
 		before(async function () {
-			this.timeout(15000);
-			const wait = getWaitHelper();
+			this.timeout(20_000);
 			await new Workbench().executeCommand('My Panel: Focus on My Panel View View');
-			// Wait for panel to be ready
-			await wait.forStable(new BottomBarPanel(), { timeout: 2000 });
+			// Confirm the panel is visible before opening the sidebar so both
+			// views are fully rendered before the nested suites switch frames.
+			await waitFor(async () => new BottomBarPanel().isDisplayed(), { timeout: 5_000, message: 'BottomBarPanel did not become visible' });
 			await new Workbench().executeCommand('Explorer: Focus on My Side Panel View View');
-			// Wait for both views to be ready
-			await wait.forStable(new SideBarView(), { timeout: 2000 });
+			await waitFor(async () => new SideBarView().isDisplayed(), { timeout: 5_000, message: 'SideBarView did not become visible' });
 		});
 		after(async () => {
 			await closeSidePanel();
@@ -124,12 +137,10 @@ describe('WebviewViews', function () {
 
 		describe('Shopping List Sidebar', function () {
 			before(async function () {
-				this.timeout(15000);
-				const wait = getWaitHelper();
+				this.timeout(15_000);
 				const sidebar = new SideBarView();
-				await wait.forStable(sidebar, { timeout: 2000 });
 				webviewView = new WebviewView(sidebar);
-				await webviewView.switchToFrame(10000);
+				await webviewView.switchToFrame(10_000);
 			});
 
 			after(async () => {
@@ -139,12 +150,10 @@ describe('WebviewViews', function () {
 		});
 		describe('Shopping List Bottombar', function () {
 			before(async function () {
-				this.timeout(15000);
-				const wait = getWaitHelper();
+				this.timeout(15_000);
 				const panel = new BottomBarPanel();
-				await wait.forStable(panel, { timeout: 2000 });
 				webviewView = new WebviewView(panel);
-				await webviewView.switchToFrame(10000);
+				await webviewView.switchToFrame(10_000);
 			});
 
 			after(async () => {

--- a/tests/test-project/src/test/workbench/input.test.ts
+++ b/tests/test-project/src/test/workbench/input.test.ts
@@ -19,28 +19,42 @@ import { expect } from 'chai';
 import { satisfies } from 'compare-versions';
 import { QuickOpenBox, Workbench, QuickPickItem, InputBox, StatusBar, EditorView, VSBrowser } from 'vscode-extension-tester';
 import { getWaitHelper, waitFor } from '../testUtils';
+import * as path from 'path';
 
 describe('QuickOpenBox', () => {
 	let input: QuickOpenBox;
 
-	before(async () => {
+	// Re-open the command prompt before each test so we always hold a fresh,
+	// interactable reference. The single shared reference from `before` goes stale
+	// after tests that scroll through quick picks or close/reopen the prompt.
+	beforeEach(async function () {
+		this.timeout(8000);
+		try {
+			// Close whatever may be open first to get a clean state
+			await input?.cancel();
+		} catch {
+			// ignore – prompt may already be closed
+		}
 		input = await new Workbench().openCommandPrompt();
 	});
 
 	after(async () => {
-		await input.cancel();
+		try {
+			await input?.cancel();
+		} catch {
+			// ignore
+		}
 	});
 
 	it('selectQuickPick works', async function () {
-		this.timeout(5000);
+		this.timeout(8000);
 		await input.setText('>hello world');
 		await input.selectQuickPick('Hello World');
 		expect(await input.isDisplayed()).is.false;
-		input = await new Workbench().openCommandPrompt();
 	});
 
 	it('can set and retrieve the text', async function () {
-		this.timeout(5000);
+		this.timeout(8000);
 		const testText = 'test-text';
 		await input.setText(testText);
 		const text = await input.getText();
@@ -48,7 +62,7 @@ describe('QuickOpenBox', () => {
 	});
 
 	it('getPlaceholder returns placeholder text', async function () {
-		this.timeout(5000);
+		this.timeout(8000);
 		await input.setText('');
 		const holder = await input.getPlaceHolder();
 
@@ -59,12 +73,14 @@ describe('QuickOpenBox', () => {
 		expect(holder).has.string(searchString);
 	});
 
-	it('hasProgress checks for progress bar', async () => {
+	it('hasProgress checks for progress bar', async function () {
+		this.timeout(8000);
 		const prog = await input.hasProgress();
 		expect(prog).is.false;
 	});
 
-	it('getQuickPicks finds quick pick options', async () => {
+	it('getQuickPicks finds quick pick options', async function () {
+		this.timeout(8000);
 		await input.setText('>hello world');
 		const picks = await input.getQuickPicks();
 		expect(picks).not.empty;
@@ -134,7 +150,7 @@ describe('QuickPickItem', () => {
 		const labels = await Promise.all(items.map((item) => item.getLabel()));
 		const filteredItems = items.filter((_, i) => labels[i] !== 'Remove from Recently Used');
 
-		expect(filteredItems.length).equals(1);
+		expect(filteredItems).to.have.lengthOf(1);
 	});
 
 	it('getLabel of Action Button works', async function () {
@@ -152,19 +168,19 @@ describe('InputBox', () => {
 	let input: InputBox;
 
 	before(async function () {
-		this.timeout(6000);
+		this.timeout(20000);
 		await new Workbench().executeCommand('Create: New File...');
-		await (await InputBox.create()).selectQuickPick('Text File');
-		// Wait for editor to be ready
+		await (await InputBox.create(8000)).selectQuickPick('Text File');
+		// Wait for editor to be ready before opening the language selection
 		await waitFor(
 			async () => {
 				const ew = new EditorView();
 				return (await ew.getOpenEditorTitles()).length > 0;
 			},
-			{ timeout: 3000 },
+			{ timeout: 8000 },
 		);
 		await new StatusBar().openLanguageSelection();
-		input = await InputBox.create();
+		input = await InputBox.create(8000);
 	});
 
 	after(async () => {
@@ -213,23 +229,40 @@ describe('InputBox - works for path', () => {
 	let input: InputBox;
 
 	before(async function () {
-		this.timeout(10000);
+		this.timeout(20000);
 		await new Workbench().executeCommand('File: Open Folder...');
-		input = await InputBox.create();
+		input = await InputBox.create(10000);
+		const resourcesPath = path.resolve(__dirname, '..', '..', '..', 'resources');
+		await input.setText(resourcesPath + path.sep);
 	});
 
 	after(async () => {
+		await input.cancel();
 		await new EditorView().closeAllEditors();
 	});
 
 	it('findQuickPick works', async function () {
-		const quickpick = await input.findQuickPick('test-folder');
+		let quickpick: QuickPickItem | undefined;
+		await waitFor(
+			async () => {
+				quickpick = await input.findQuickPick('test-folder');
+				return quickpick !== undefined;
+			},
+			{ timeout: 8000, message: 'Could not find quick pick with text "test-folder"' },
+		);
 		expect(quickpick).to.not.be.undefined;
 	});
 
 	it('selectQuickPick works', async function () {
 		await input.selectQuickPick('test-folder');
-		const quickpick2 = await input.findQuickPick('foolder');
+		let quickpick2: QuickPickItem | undefined;
+		await waitFor(
+			async () => {
+				quickpick2 = await input.findQuickPick('foolder');
+				return quickpick2 !== undefined;
+			},
+			{ timeout: 8000, message: 'Could not find quick pick with text "foolder" after selecting "test-folder"' },
+		);
 		expect(quickpick2).to.not.be.undefined;
 	});
 });
@@ -237,12 +270,13 @@ describe('InputBox - works for path', () => {
 describe('Multiple selection input', () => {
 	let input: InputBox;
 
-	before(async () => {
+	before(async function () {
+		this.timeout(15000);
 		const wait = getWaitHelper();
 		await new Workbench().executeCommand('Test Quickpicks');
 		// Wait for input box to appear and stabilize
-		input = await InputBox.create();
-		await wait.forStable(input, { timeout: 1000 });
+		input = await InputBox.create(8000);
+		await wait.forStable(input, { timeout: 2000 });
 	});
 
 	after(async () => {

--- a/tests/test-project/src/test/workbench/notifications.test.ts
+++ b/tests/test-project/src/test/workbench/notifications.test.ts
@@ -32,23 +32,23 @@ describe('NotificationsCenter', () => {
 	});
 
 	it('getNotifications works', async function () {
-		this.timeout(4000);
+		this.timeout(10000);
 		await new Workbench().executeCommand('Hello World');
-		// Wait for notification to appear
+		// Re-open the center after triggering the command so the notification is visible
 		center = await new Workbench().openNotificationsCenter();
 		await waitFor(
 			async () => {
 				const notifications = await center.getNotifications(NotificationType.Any);
 				return notifications.length > 0;
 			},
-			{ timeout: 2000, message: 'Notifications did not appear' },
+			{ timeout: 5000, message: 'Notifications did not appear' },
 		);
 		const notifications = await center.getNotifications(NotificationType.Any);
 		expect(notifications).not.empty;
 	});
 
 	it('clearAllNotifications works', async function () {
-		this.timeout(8000);
+		this.timeout(15000);
 		await new Workbench().executeCommand('Hello World');
 		center = await new Workbench().openNotificationsCenter();
 		// Wait for notification to appear
@@ -57,13 +57,13 @@ describe('NotificationsCenter', () => {
 				const notifications = await center.getNotifications(NotificationType.Any);
 				return notifications.length > 0;
 			},
-			{ timeout: 2000 },
+			{ timeout: 5000 },
 		);
 		const notifications = await center.getNotifications(NotificationType.Any);
 		expect(notifications).not.empty;
 
 		await center.clearAllNotifications();
-		// Wait for center to close
+		// Wait for center to close after clearing
 		await waitFor(
 			async () => {
 				try {
@@ -72,7 +72,7 @@ describe('NotificationsCenter', () => {
 					return true;
 				}
 			},
-			{ timeout: 3000 },
+			{ timeout: 6000 },
 		);
 		expect(await center.isDisplayed()).is.false;
 	});
@@ -80,16 +80,17 @@ describe('NotificationsCenter', () => {
 	describe('Notification', () => {
 		let notification: Notification;
 
-		before(async () => {
+		before(async function () {
+			this.timeout(12000);
 			await new Workbench().executeCommand('Test Notification');
 			center = await new Workbench().openNotificationsCenter();
-			// Wait for notification to appear
+			// Wait for the 'Test Notification' to appear in the center
 			await waitFor(
 				async () => {
 					const notifications = await center.getNotifications(NotificationType.Any);
 					return notifications.length > 0;
 				},
-				{ timeout: 2000 },
+				{ timeout: 6000 },
 			);
 			notification = (await center.getNotifications(NotificationType.Any))[0];
 		});
@@ -139,10 +140,11 @@ describe('NotificationsCenter', () => {
 			await driver.wait(until.stalenessOf(notification));
 		});
 
-		it('dismiss works', async () => {
+		it('dismiss works', async function () {
+			this.timeout(15000);
 			await new Workbench().executeCommand('Test Notification');
 			center = await new Workbench().openNotificationsCenter();
-			await waitFor(async () => (await center.getNotifications(NotificationType.Any)).length > 0, { timeout: 2000 });
+			await waitFor(async () => (await center.getNotifications(NotificationType.Any)).length > 0, { timeout: 6000 });
 			notification = (await center.getNotifications(NotificationType.Any))[0];
 
 			const driver = notification.getDriver();
@@ -150,10 +152,11 @@ describe('NotificationsCenter', () => {
 			await driver.wait(until.stalenessOf(notification));
 		});
 
-		it('get warning notification works', async () => {
+		it('get warning notification works', async function () {
+			this.timeout(15000);
 			await new Workbench().executeCommand('Warning Message');
 			center = await new Workbench().openNotificationsCenter();
-			await waitFor(async () => (await center.getNotifications(NotificationType.Warning)).length > 0, { timeout: 2000 });
+			await waitFor(async () => (await center.getNotifications(NotificationType.Warning)).length > 0, { timeout: 6000 });
 			notification = (await center.getNotifications(NotificationType.Warning))[0];
 
 			expect(await notification.getMessage()).to.equal('This is a warning!');
@@ -162,10 +165,11 @@ describe('NotificationsCenter', () => {
 			await center.getDriver().wait(until.stalenessOf(notification));
 		});
 
-		it('get error notification works', async () => {
+		it('get error notification works', async function () {
+			this.timeout(15000);
 			await new Workbench().executeCommand('Error Message');
 			center = await new Workbench().openNotificationsCenter();
-			await waitFor(async () => (await center.getNotifications(NotificationType.Error)).length > 0, { timeout: 2000 });
+			await waitFor(async () => (await center.getNotifications(NotificationType.Error)).length > 0, { timeout: 6000 });
 			notification = (await center.getNotifications(NotificationType.Error))[0];
 
 			expect(await notification.getMessage()).to.equal('This is an error!');

--- a/tests/test-project/src/test/workbench/open.test.ts
+++ b/tests/test-project/src/test/workbench/open.test.ts
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-import { EditorView, VSBrowser, Workbench } from 'vscode-extension-tester';
+import { EditorView, VSBrowser, Workbench, InputBox } from 'vscode-extension-tester';
 import * as path from 'path';
+import { waitFor } from '../testUtils';
 
 describe('Simple open file dialog', function () {
 	const filePath = path.resolve('.', 'package.json');
@@ -26,15 +27,32 @@ describe('Simple open file dialog', function () {
 	});
 
 	it('Opens a file', async function () {
-		this.timeout(30000);
+		this.timeout(60000);
 		const input = await new Workbench().openCommandPrompt();
 		await input.setText('>File: Open File...');
+		await waitFor(
+			async () => {
+				const pick = await input.findQuickPick('File: Open File...');
+				return pick !== undefined;
+			},
+			{ timeout: 8000, message: 'Could not find quick pick "File: Open File..."' },
+		);
 		await input.selectQuickPick('File: Open File...');
-		await new Promise((res) => setTimeout(res, 1000));
-		await input.setText(filePath);
-		await new Promise((res) => setTimeout(res, 1000));
-		await input.selectQuickPick('package.json');
-		await new Promise((res) => setTimeout(res, 1000));
+
+		// Give VS Code time to switch from command mode to the file-open dialog —
+		// InputBox.create uses a fixed 5 s default which is too tight on slow CI runners.
+		const prompt = await InputBox.create(15000);
+		await waitFor(
+			async () => {
+				const text = await prompt.getText();
+				return !text.startsWith('>');
+			},
+			{ timeout: 8000, message: 'Input box did not transition from command prompt to file dialog' },
+		);
+
+		await prompt.setText(filePath);
+		await prompt.getDriver().sleep(500);
+		await prompt.confirmPath();
 
 		await VSBrowser.instance.driver.wait(
 			async () => {
@@ -45,7 +63,7 @@ describe('Simple open file dialog', function () {
 					return false;
 				}
 			},
-			this.timeout() - 10000,
+			20000,
 			`No editor with title 'package.json' available.`,
 		);
 	});

--- a/tests/test-project/src/test/workbench/workbench.test.ts
+++ b/tests/test-project/src/test/workbench/workbench.test.ts
@@ -17,6 +17,7 @@
 
 import { expect } from 'chai';
 import { EditorView, Workbench } from 'vscode-extension-tester';
+import { waitFor } from '../testUtils';
 
 describe('Workbench', () => {
 	let bench: Workbench;
@@ -73,9 +74,16 @@ describe('Workbench', () => {
 		await prompt.cancel();
 	});
 
-	it('executeCommand works', async () => {
+	it('executeCommand works', async function () {
+		this.timeout(15000);
 		await bench.executeCommand('Hello World');
-		await bench.getDriver().sleep(500);
+		await waitFor(
+			async () => {
+				const notifications = await bench.getNotifications();
+				return notifications.length > 0;
+			},
+			{ timeout: 8000, message: 'Notification did not appear after executeCommand "Hello World"' },
+		);
 		const notifications = await bench.getNotifications();
 		expect(notifications).not.empty;
 
@@ -84,7 +92,7 @@ describe('Workbench', () => {
 	});
 
 	it('openSettings opens the settings editor', async function () {
-		this.timeout(8000);
+		this.timeout(15000);
 		const editor = await bench.openSettings();
 		expect(await editor.getTitle()).equals('Settings');
 		await new EditorView().closeAllEditors();

--- a/tests/test-project/src/test/xsideBar/customView.test.ts
+++ b/tests/test-project/src/test/xsideBar/customView.test.ts
@@ -33,6 +33,7 @@ import {
 	WelcomeContentSection,
 	Workbench,
 } from 'vscode-extension-tester';
+import { waitFor } from '../testUtils';
 
 describe('CustomTreeSection', () => {
 	let section: CustomTreeSection;
@@ -41,12 +42,18 @@ describe('CustomTreeSection', () => {
 	let content: ViewContent;
 
 	before(async function () {
-		this.timeout(5000);
+		this.timeout(20_000);
 		const view = await ((await new ActivityBar().getViewControl('Explorer')) as ViewControl).openView();
-		await new Promise((res) => {
-			setTimeout(res, 1000);
-		});
 		content = view.getContent();
+		// Wait for the extension's tree-view providers to register their sections
+		await waitFor(
+			async () => {
+				const sections = await content.getSections();
+				const titles = await Promise.all(sections.map((s) => s.getTitle()));
+				return titles.includes('Test View') && titles.includes('Test View 2') && titles.includes('Empty View');
+			},
+			{ timeout: 15_000, message: 'Custom view sections did not appear in Explorer' },
+		);
 		section = await content.getSection('Test View');
 		emptySection = await content.getSection('Test View 2');
 		await emptySection.expand();
@@ -55,9 +62,6 @@ describe('CustomTreeSection', () => {
 
 	after(async () => {
 		await ((await new ActivityBar().getViewControl('Explorer')) as ViewControl).closeView();
-		await new Promise((res) => {
-			setTimeout(res, 1000);
-		});
 	});
 
 	it('getTitle works', async () => {
@@ -69,7 +73,6 @@ describe('CustomTreeSection', () => {
 		await section.collapse();
 		expect(await section.isExpanded()).is.false;
 
-		await new Promise((res) => setTimeout(res, 500));
 		await section.expand();
 		expect(await section.isExpanded()).is.true;
 	});
@@ -172,11 +175,14 @@ describe('CustomTreeSection', () => {
 	describe('WelcomeContentButton', () => {
 		it('takeAction executes the command', async function () {
 			this.timeout(10_000);
-			await new Promise((res) => setTimeout(res, 500));
 			const button = await ((await emptyViewSection.findWelcomeContent()) as WelcomeContentSection).getButton('Add stuff into this View');
 			expect(button).to.be.not.be.undefined;
 			await button?.click();
-			await new Promise((res) => setTimeout(res, 1_000));
+			// Wait until welcome content disappears (items were added to the view)
+			await waitFor(async () => (await emptyViewSection.findWelcomeContent()) === undefined, {
+				timeout: 8_000,
+				message: 'Welcome content did not disappear after clicking action button',
+			});
 			expect(await emptyViewSection.findWelcomeContent()).to.be.undefined;
 		});
 	});
@@ -262,11 +268,22 @@ describe('CustomTreeSection', () => {
 			let bench: Workbench;
 
 			before(async function () {
+				this.timeout(15_000);
 				const view = await ((await new ActivityBar().getViewControl('Explorer')) as ViewControl).openView();
-				await view.getDriver().sleep(1_000);
 				content = view.getContent();
-				section = await content.getSection('Test View');
-				dItem = await section.findItem('d');
+				// Wait for Test View section to be ready before looking for items
+				await waitFor(
+					async () => {
+						try {
+							section = await content.getSection('Test View');
+							dItem = await section.findItem('d');
+							return dItem !== undefined;
+						} catch {
+							return false;
+						}
+					},
+					{ timeout: 12_000, message: 'Item "d" not found in Test View' },
+				);
 				bench = new Workbench();
 			});
 

--- a/tests/test-project/src/test/xsideBar/scmView.test.ts
+++ b/tests/test-project/src/test/xsideBar/scmView.test.ts
@@ -20,23 +20,43 @@ import * as path from 'path';
 import { expect } from 'chai';
 import * as fs from 'fs-extra';
 import { satisfies } from 'compare-versions';
+import { waitFor } from '../testUtils';
 
 (satisfies(VSBrowser.instance.version, '>=1.38.0') ? describe : describe.skip)('SCM View', () => {
 	let view: ScmView;
 
 	before(async function () {
-		this.timeout(15000);
+		this.timeout(30_000);
 		fs.writeFileSync(path.resolve('.', 'testfile'), 'content');
 		await VSBrowser.instance.openResources(path.resolve('..', '..'), async () => {
-			await VSBrowser.instance.driver.sleep(3_000);
+			await VSBrowser.instance.driver.sleep(1_000);
 		});
 		await VSBrowser.instance.waitForWorkbench();
 		view = (await ((await new ActivityBar().getViewControl('Source Control')) as ViewControl).openView()) as ScmView;
-		await view.getDriver().sleep(5_000); // wait until scm changes are loaded
+		// Wait until SCM changes are loaded (at least one provider with changes)
+		await waitFor(
+			async () => {
+				try {
+					const providers = await view.getProviders();
+					if (providers.length === 0) {
+						return false;
+					}
+					const changes = await providers[0].getChanges(false);
+					return changes.length > 0;
+				} catch {
+					return false;
+				}
+			},
+			{ timeout: 20_000, message: 'SCM changes did not load' },
+		);
 	});
 
 	after(() => {
-		fs.unlinkSync(path.resolve('.', 'testfile'));
+		try {
+			fs.unlinkSync(path.resolve('.', 'testfile'));
+		} catch {
+			// the file may not exist if the before hook failed part-way
+		}
 	});
 
 	it('getProviders works', async () => {
@@ -133,7 +153,12 @@ import { satisfies } from 'compare-versions';
 				const act = await change.takeAction('Open File');
 				expect(act).to.be.true;
 
-				expect(await new EditorView().getOpenEditorTitles()).contains('testfile');
+				const editorView = new EditorView();
+				await waitFor(async () => (await editorView.getOpenEditorTitles()).includes('testfile'), {
+					timeout: 5_000,
+					message: 'Editor tab for "testfile" did not open',
+				});
+				expect(await editorView.getOpenEditorTitles()).contains('testfile');
 			});
 		});
 	});

--- a/tests/test-project/src/test/xsideBar/sideBarView.test.ts
+++ b/tests/test-project/src/test/xsideBar/sideBarView.test.ts
@@ -83,15 +83,30 @@ describe('SideBarView', () => {
 		let content: ViewContent;
 
 		before(async function () {
-			this.timeout(15000);
+			this.timeout(20_000);
 			const wait = getWaitHelper();
 			await VSBrowser.instance.openResources(path.resolve(__dirname, '..', '..', '..', 'resources', 'test-folder'), async () => {
-				await wait.sleep(3000);
+				await wait.sleep(1_000);
 			});
 			view = await ((await new ActivityBar().getViewControl('Explorer')) as ViewControl).openView();
-			// Wait for content to be ready
-			await wait.forStable(view, { timeout: 2000 });
 			content = view.getContent();
+			// Wait for the test-folder section to appear in the Explorer
+			await wait.forCondition(
+				async () => {
+					try {
+						const sections = await content.getSections();
+						for (const s of sections) {
+							if ((await s.getTitle()) === 'test-folder') {
+								return true;
+							}
+						}
+						return false;
+					} catch {
+						return false;
+					}
+				},
+				{ timeout: 15_000, message: 'test-folder section did not appear in Explorer' },
+			);
 		});
 
 		after(async function () {


### PR DESCRIPTION
## Motivation

The existing `Main CI` workflow runs the entire UI test suite as a single monolithic block per OS × VS Code version. This makes it hard to identify which area of the framework is broken, wastes runner time retrying everything when only one group fails, and produces a single undifferentiated job entry in PR checks.

Splitting the suite also surfaced a set of long-standing framework and test reliability problems that a monolithic retried run had been masking. This PR therefore has two halves: the **CI split** itself, and the **stabilization work** required to make every group pass on the first run — the per-group jobs deliberately have **no retry wrapper**, so root causes had to be fixed rather than retried away.

## What this PR does

Splits the UI test suite into **13 parallel jobs** — one per test group directory — each running across a **3-OS × min/max VS Code version matrix (6 sub-jobs per group)**. A single aggregated `🚦 Status Check` job gates branch protection, so the PR check signal is unchanged.

On top of that, it hardens the extester core, the page objects and the test suites based on root-cause analysis of failing runs (job logs, failure screenshots and chromedriver traces).

## Commit structure

| Commit | Scope |
|---|---|
| `ci: split main CI pipeline into per-test-group parallel jobs` | workflows, shared config, npm scripts |
| `fix(extester): harden download, session lifecycle and shutdown for CI` | `packages/extester` |
| `fix(webview): reliable iframe detection and frame switching` | WebviewMixin/WebView/locators — **fixes #2450** |
| `fix(page-objects): performance and stale-element hardening` | `packages/page-objects` |
| `test(ui): stabilize suites for parallel single-run execution` | `tests/test-project` |

## CI split

- New reusable `.github/workflows/template-suite.yaml` (inputs: `test_group`, `nodejs`, `code_type`); runs `ubuntu/macos/windows × min/max`. Jobs are **single-run** — a failed group is cheap to re-run manually, and first-run stability is the goal.
- `main.yml` replaces the monolithic job with 13 group jobs + the `🚦 Status Check` aggregator.
- **One shared `extester.config.json`** serves all groups; each `test:<group>` npm script passes its group's test files as positional globs (CLI args take precedence over config `testFiles`; the `cli` group keeps its `order-3 → order-2 → order-1` ordering). Root-level tests (`resourceLaunchArg`) run in the `01_general` group so they stay in PR gating.
- Screenshots + chromedriver log are uploaded as per-job artifacts on failure.

## Problems found and fixed

Root causes identified across five iterations of failing matrix runs:

**Framework — extester core**
- `ContentAssist.getItem` scanned suggestions at ~0.65 s/page (fixed sleeps + ~5 WebDriver round-trips per row) → 15 s timeouts on every platform. Now reads all rendered rows in a single `executeScript` call per page and waits for the visible range to move: beyond-visible-range lookups drop to ~2.5 s.
- `waitForWorkbench` raced window reloads (opening a folder reloads the workbench) and threw uncaught `NoSuchElementError`. Now a single resilient poll that also re-attaches when the window handle dies.
- On macOS the running VS Code instance can permanently stop honoring CLI `code -r <file>` open requests after a workspace-switch reload. `openResources` now verifies the tabs appeared, retries the CLI once, then falls back to the workbench quick open box; failures surface as one clear error.
- Corrupted VS Code archives (truncated download / stale cache) produced a broken install that failed minutes later ("installation appears to be corrupt", extension host version mismatch). Downloads are atomic and integrity-checked (`unzip -t` / `tar -tzf`) with one automatic re-download.
- Emergency shutdown bounds `driver.quit()` (5 s) and installs no `uncaughtException` handler (it competed with Mocha's own and aborted whole suites on stray async errors). Failure screenshots are captured only for `failed` tests — skipped tests no longer produce misleading artifacts.

**Framework — page objects**
- Stale-element recovery that actually recovers (`ViewControl` re-locates itself by cached title; `withRecovery`/`reinitialize`).
- Sample-once races converted to bounded polls: `SettingsEditor.findSetting*` row scan, `Input.confirmPath` (tolerates the picker closing itself after the first Enter), `BottomBarPanel.resize` and `FindWidget` clicks mid-animation.
- Webview iframe detection uses the class-based `iframe.webview.ready` locator and `switchToFrame` polls outer + active frame under one deadline with a descriptive error (#2450).

**Tests**
- Global mocha timeout raised 10 s → 30 s: the slowest CI runners are 4–5× slower than average and the page objects' condition waits legitimately need 10–30 s there; the old budget made tests a timing lottery.
- Fixed sleeps replaced with condition waits; cleanup hooks guarded so they cannot mask the original failure; environment-dependent assertions removed (e.g. suggestions look for the ES-lib global `Math`, not `Buffer` which requires async `@types/node` acquisition); stale-tolerant polling where lists re-render asynchronously.

**Quality gate (SonarCloud)**
- ChromeDriver version strings are validated (`^\d+(\.\d+){0,3}$`) before flowing into URLs/paths/process args/logs, and the local version probe uses `execFile` (no shell) — resolves the command-injection blocker and the log-leak finding. Minor maintainability findings (Set lookup, redundant argument, optional chain) addressed.

## Verification

- Full 13-group × 6-platform matrix **green on the first run, without retries** (run [33168235857](https://github.com/redhat-developer/vscode-extension-tester/actions/runs/33168235857); consolidation and Sonar fixes are content-verified against that tree).
- Affected groups additionally verified locally against the CI-pinned VS Code 1.131.0 after every fix round.

## What is NOT changed
- `template-main.yaml`, `insiders.yml`, `nodejs.yml`, `template-runner.yaml`, `runner.yaml`, `coverage.yml` — unchanged; nightly/coverage flows still run the full suite.

## PR check layout (after merge)
```
🏗️ Main CI
├── 🧪 Unit Tests              (ubuntu-latest)
├── 🧪 01_general … xsideBar   → 13 groups × 6 matrix sub-jobs (3 OS × min/max)
├── runner                     → template-runner.yaml (3 OS)
└── 🚦 Status Check            (single green/red gate)
```
