### PR TITLE
feat(extester): support extends in extester.config.json

### DIFF
--- a/docs/Test-Setup.md
+++ b/docs/Test-Setup.md
@@ -219,19 +219,48 @@ To point to a specific file instead:
 extest setup-and-run --config ./config/extester.config.json
 ```
 
+### Extending config files
+
+A config file can inherit from one or more base config files via the top-level `extends` field — useful for sharing one base config across packages in a monorepo while overriding only what differs (e.g. the `testFiles` globs):
+
+```json
+// <repo root>/extester.base.json
+{
+  "setup": { "vscodeVersion": "latest", "installDependencies": true },
+  "run": { "logLevel": "Info" }
+}
+```
+
+```json
+// packages/my-extension/extester.config.json
+{
+  "extends": "../../extester.base.json",
+  "run": { "testFiles": ["./out/test/**/*.test.js"] }
+}
+```
+
+Merge rules:
+
+- `extends` accepts a single path or an array of paths (relative or absolute). Relative paths resolve against the directory of the file that declares them.
+- With multiple bases, later entries override earlier ones, and the extending file overrides all of its bases.
+- Objects are deep-merged; **arrays and scalars are replaced whole, not concatenated** — setting `testFiles` in an extending file fully replaces the base's globs.
+- Relative paths _inside_ each config file resolve against that file's own directory, so a base config's `storage` or `testFiles` stay anchored to the base file's location.
+- Chains are allowed (a base may itself extend another file); circular chains are reported as an error.
+- The `extends` field never appears in the effective config.
+
 ### Precedence
 
 Settings are resolved in this order — later sources override earlier ones:
 
 ```
-built-in defaults  ←  extester.config.json  ←  CLI flags
+built-in defaults  ←  extended base configs (in order)  ←  extester.config.json  ←  CLI flags
 ```
 
 Environment variables (`CODE_VERSION`, `TEST_RESOURCES`, etc.) continue to apply at their existing layer inside ExTester and are not affected by the config file.
 
 ### Config file reference
 
-All fields are optional. Paths are resolved relative to the config file's location.
+All fields are optional. Paths are resolved relative to the config file's location. The top-level `extends` field is described in [Extending config files](#extending-config-files).
 
 #### `setup` section
 

--- a/packages/extester/resources/extester.schema.json
+++ b/packages/extester/resources/extester.schema.json
@@ -10,6 +10,14 @@
       "type": "string",
       "description": "Path or URL to the JSON Schema for this file."
     },
+    "extends": {
+      "description": "Path(s) to base config file(s) to inherit from. Relative paths resolve against this file's directory. Later entries override earlier ones; this file overrides all bases. Objects deep-merge; arrays and scalars are replaced whole.",
+      "oneOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+      ],
+      "examples": ["../../extester.base.json"]
+    },
     "setup": {
       "type": "object",
       "description": "Setup options: controls VS Code + ChromeDriver download and extension packaging/installation.",

--- a/packages/extester/src/config.ts
+++ b/packages/extester/src/config.ts
@@ -89,6 +89,13 @@ export interface ExTesterRunConfig {
  * ```
  */
 export interface ExTesterConfig {
+	/**
+	 * Path(s) to base config file(s) to inherit from. Relative paths resolve against the
+	 * directory of the config file that declares them. Later entries override earlier ones;
+	 * this file overrides all bases. Objects are deep-merged; arrays and scalars are replaced
+	 * whole. Never present in the loaded result.
+	 */
+	extends?: string | string[];
 	/** Setup options: VS Code download, ChromeDriver, and extension installation. */
 	setup?: ExTesterSetupConfig;
 	/** Run options: test execution inside VS Code. */
@@ -177,18 +184,120 @@ function resolvePaths(config: ExTesterConfig, baseDir: string): ExTesterConfig {
 	return config;
 }
 
+/** Returns true for plain (non-array) objects — the only values that are deep-merged. */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 /**
- * Loads and parses an `extester.config.json` configuration file.
- *
- * - If `configPath` is provided, that exact file is read (throws if it does not exist).
- * - If `configPath` is omitted, `find-up` walks from `process.cwd()` looking for
- *   `extester.config.json`. Returns `{}` when no file is found.
- * - All relative paths inside the config are resolved relative to the directory containing
- *   the config file, so paths work regardless of where `extest` is invoked from.
- *
- * @param configPath Optional explicit path to the config file.
- * @returns Parsed and path-resolved {@link ExTesterConfig}. Empty object when no file is found.
+ * Deep-merges `override` into `base` and returns a new object.
+ * Plain objects merge recursively; arrays and scalars in `override` replace the base value whole.
+ * `__proto__`/`constructor`/`prototype` keys are skipped to prevent prototype pollution.
  */
+function mergeConfigs(base: Record<string, unknown>, override: Record<string, unknown>): Record<string, unknown> {
+	const result: Record<string, unknown> = { ...base };
+	for (const key of Object.keys(override)) {
+		if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+			continue;
+		}
+		const baseVal = result[key];
+		const overrideVal = override[key];
+		result[key] = isPlainObject(baseVal) && isPlainObject(overrideVal) ? mergeConfigs(baseVal, overrideVal) : overrideVal;
+	}
+	return result;
+}
+
+/**
+ * Reads and parses a single config file. Error messages name this specific file, so with
+ * `extends` chains the failing file (base or child) is always identifiable.
+ */
+function readConfigFile(filePath: string): ExTesterConfig {
+	try {
+		const stat = statSync(filePath);
+		if (!stat.isFile()) {
+			throw new Error(`extester config: path is not a file: ${filePath}`);
+		}
+	} catch (err: unknown) {
+		if (err instanceof Error && err.message.startsWith('extester config:')) {
+			throw err;
+		}
+		throw new Error(`extester config: file not found: ${filePath}`);
+	}
+
+	let raw: string;
+	try {
+		raw = readFileSync(filePath, 'utf8');
+	} catch {
+		throw new Error(`extester config: could not read file: ${filePath}`);
+	}
+
+	try {
+		return JSON.parse(raw) as ExTesterConfig;
+	} catch {
+		throw new Error(`extester config: invalid JSON in ${filePath}`);
+	}
+}
+
+/**
+ * Resolves an `extends` target declared inside a config file to a canonical path.
+ *
+ * Unlike {@link safeConfigPath} (which gates CLI-provided `--config` input per SonarCloud
+ * rule tssecurity:S8707), extends targets are NOT restricted to cwd/tmpdir: the specifier
+ * comes from a config file the user already owns and explicitly loaded, not from untrusted
+ * process input, and the primary use case is a shared base config ABOVE the package
+ * directory (e.g. a monorepo root). The path is still canonicalised via realpathSync and
+ * must have a .json extension.
+ */
+function safeExtendsPath(specifier: string, declaringDir: string): string {
+	const resolved = path.isAbsolute(specifier) ? specifier : path.resolve(declaringDir, specifier);
+	let canonical: string;
+	try {
+		canonical = realpathSync(resolved);
+	} catch {
+		throw new Error(`extester config: extended config file not found: ${resolved}`);
+	}
+	if (path.extname(canonical).toLowerCase() !== '.json') {
+		throw new Error(`extester config: extended config file must be a .json file: ${canonical}`);
+	}
+	return canonical;
+}
+
+/**
+ * Loads a config file and recursively merges in its `extends` bases.
+ *
+ * Each file's relative paths are resolved against its own directory BEFORE merging, so
+ * paths declared in a base config stay anchored to the base file's location. Bases are
+ * merged in declaration order (later ones win) and the extending file is merged last.
+ *
+ * @param canonicalPath Canonical (realpath'd) path of the config file to load.
+ * @param visited Chain of canonical paths currently being loaded, for cycle detection.
+ */
+function loadConfigWithExtends(canonicalPath: string, visited: string[]): ExTesterConfig {
+	if (visited.includes(canonicalPath)) {
+		throw new Error(`extester config: circular extends detected: ${[...visited, canonicalPath].join(' -> ')}`);
+	}
+	const parsed = readConfigFile(canonicalPath);
+	const dir = path.dirname(canonicalPath);
+
+	// Consume `extends` before path resolution and merging so it never appears in the result.
+	const extendsValue = parsed.extends;
+	delete parsed.extends;
+	const specifiers = typeof extendsValue === 'string' ? [extendsValue] : (extendsValue ?? []);
+	if (!Array.isArray(specifiers) || specifiers.some((spec) => typeof spec !== 'string')) {
+		throw new Error(`extester config: "extends" must be a string or an array of strings in ${canonicalPath}`);
+	}
+
+	const self = resolvePaths(parsed, dir);
+	const chain = [...visited, canonicalPath];
+	let merged: Record<string, unknown> = {};
+	for (const spec of specifiers) {
+		// Earlier bases are merged first, so later entries override earlier ones.
+		const base = loadConfigWithExtends(safeExtendsPath(spec, dir), chain);
+		merged = mergeConfigs(merged, base as Record<string, unknown>);
+	}
+	return mergeConfigs(merged, self as Record<string, unknown>) as ExTesterConfig;
+}
+
 /**
  * Resolves a config file path from CLI input to a safe canonical path.
  *
@@ -229,6 +338,21 @@ function safeConfigPath(filePath: string): string {
 	return resolved;
 }
 
+/**
+ * Loads and parses an `extester.config.json` configuration file.
+ *
+ * - If `configPath` is provided, that exact file is read (throws if it does not exist).
+ * - If `configPath` is omitted, `find-up` walks from `process.cwd()` looking for
+ *   `extester.config.json`. Returns `{}` when no file is found.
+ * - A top-level `extends` field (string or array of file paths) pulls in base config
+ *   file(s), which are deep-merged underneath this file's own values. See
+ *   {@link loadConfigWithExtends} for the merge rules.
+ * - All relative paths inside each config file are resolved relative to the directory
+ *   containing that file, so paths work regardless of where `extest` is invoked from.
+ *
+ * @param configPath Optional explicit path to the config file.
+ * @returns Parsed, merged and path-resolved {@link ExTesterConfig}. Empty object when no file is found.
+ */
 export async function loadConfig(configPath?: string): Promise<ExTesterConfig> {
 	let safePath: string | undefined;
 
@@ -248,31 +372,5 @@ export async function loadConfig(configPath?: string): Promise<ExTesterConfig> {
 		return {};
 	}
 
-	try {
-		const stat = statSync(safePath);
-		if (!stat.isFile()) {
-			throw new Error(`extester config: path is not a file: ${safePath}`);
-		}
-	} catch (err: unknown) {
-		if (err instanceof Error && err.message.startsWith('extester config:')) {
-			throw err;
-		}
-		throw new Error(`extester config: file not found: ${safePath}`);
-	}
-
-	let raw: string;
-	try {
-		raw = readFileSync(safePath, 'utf8');
-	} catch {
-		throw new Error(`extester config: could not read file: ${safePath}`);
-	}
-
-	let parsed: ExTesterConfig;
-	try {
-		parsed = JSON.parse(raw) as ExTesterConfig;
-	} catch {
-		throw new Error(`extester config: invalid JSON in ${safePath}`);
-	}
-
-	return resolvePaths(parsed, path.dirname(safePath));
+	return loadConfigWithExtends(safePath, []);
 }

--- a/packages/extester/src/test/config.test.ts
+++ b/packages/extester/src/test/config.test.ts
@@ -34,6 +34,16 @@ function makeTmpConfig(content: string): { dir: string; file: string } {
 	return { dir, file };
 }
 
+/**
+ * Writes an additional config file (creating subdirectories as needed) under an existing tmp dir.
+ */
+function writeExtraConfig(dir: string, relPath: string, content: string): string {
+	const file = path.join(dir, relPath);
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, content, 'utf8');
+	return file;
+}
+
 describe('loadConfig', () => {
 	describe('auto-discovery', () => {
 		it('returns an empty object when no extester.config.json is found', async () => {
@@ -212,6 +222,250 @@ describe('loadConfig', () => {
 				assert.strictEqual(cfg.run?.locale, undefined);
 			} finally {
 				fs.rmSync(path.dirname(file), { recursive: true });
+			}
+		});
+	});
+
+	describe('extends', () => {
+		it('inherits values from a single extended base and strips the extends key', async () => {
+			const { dir, file } = makeTmpConfig(JSON.stringify({ extends: './base.json' }));
+			writeExtraConfig(dir, 'base.json', JSON.stringify({ setup: { vscodeVersion: '1.131.0' }, run: { logLevel: 'Debug' } }));
+			try {
+				const cfg = await loadConfig(file);
+				assert.strictEqual(cfg.setup?.vscodeVersion, '1.131.0');
+				assert.strictEqual(cfg.run?.logLevel, 'Debug');
+				assert.ok(!('extends' in cfg), 'extends key must not appear in the loaded config');
+			} finally {
+				fs.rmSync(dir, { recursive: true });
+			}
+		});
+
+		it('lets the extending file override a scalar from the base', async () => {
+			const { dir, file } = makeTmpConfig(JSON.stringify({ extends: './base.json', setup: { vscodeVersion: 'max' } }));
+			writeExtraConfig(dir, 'base.json', JSON.stringify({ setup: { vscodeVersion: '1.131.0', type: 'insider' } }));
+			try {
+				const cfg = await loadConfig(file);
+				assert.strictEqual(cfg.setup?.vscodeVersion, 'max');
+				assert.strictEqual(cfg.setup?.type, 'insider');
+			} finally {
+				fs.rmSync(dir, { recursive: true });
+			}
+		});
+
+		it('deep-merges nested objects from base and extending file', async () => {
+			const { dir, file } = makeTmpConfig(JSON.stringify({ extends: './base.json', setup: { packageOptions: { preRelease: true } } }));
+			writeExtraConfig(dir, 'base.json', JSON.stringify({ setup: { packageOptions: { useYarn: true } } }));
+			try {
+				const cfg = await loadConfig(file);
+				assert.strictEqual(cfg.setup?.packageOptions?.useYarn, true);
+				assert.strictEqual(cfg.setup?.packageOptions?.preRelease, true);
+			} finally {
+				fs.rmSync(dir, { recursive: true });
+			}
+		});
+
+		it('replaces arrays whole instead of concatenating them', async () => {
+			const { dir, file } = makeTmpConfig(JSON.stringify({ extends: './base.json', run: { testFiles: ['./b/**/*.test.js'] } }));
+			writeExtraConfig(dir, 'base.json', JSON.stringify({ run: { testFiles: ['./a/**/*.test.js'], resources: ['./fixtures'] } }));
+			const dirFwd = dir.split(path.sep).join('/');
+			try {
+				const cfg = await loadConfig(file);
+				// Child's testFiles fully replace the base's, resolved against the child's directory.
+				assert.deepStrictEqual(cfg.run?.testFiles, [`${dirFwd}/b/**/*.test.js`]);
+				// Untouched base arrays are inherited, resolved against the base's directory.
+				assert.deepStrictEqual(cfg.run?.resources, [path.resolve(dir, 'fixtures')]);
+			} finally {
+				fs.rmSync(dir, { recursive: true });
+			}
+		});
+
+		it('applies multiple bases in order, later entries overriding earlier ones', async () => {
+			const { dir, file } = makeTmpConfig(JSON.stringify({ extends: ['./base1.json', './base2.json'], run: { locale: 'fr' } }));
+			writeExtraConfig(dir, 'base1.json', JSON.stringify({ setup: { vscodeVersion: '1.130.0' }, run: { locale: 'ru', cleanup: true } }));
+			writeExtraConfig(dir, 'base2.json', JSON.stringify({ setup: { vscodeVersion: '1.131.0' } }));
+			try {
+				const cfg = await loadConfig(file);
+				assert.strictEqual(cfg.setup?.vscodeVersion, '1.131.0');
+				assert.strictEqual(cfg.run?.locale, 'fr');
+				assert.strictEqual(cfg.run?.cleanup, true);
+			} finally {
+				fs.rmSync(dir, { recursive: true });
+			}
+		});
+
+		it('follows extends chains across multiple levels', async () => {
+			const { dir, file } = makeTmpConfig(JSON.stringify({ extends: './b.json', setup: { vscodeVersion: 'max' } }));
+			writeExtraConfig(dir, 'b.json', JSON.stringify({ extends: './a.json', setup: { vscodeVersion: '1.131.0', type: 'insider' } }));
+			writeExtraConfig(dir, 'a.json', JSON.stringify({ setup: { vscodeVersion: '1.130.0', installDependencies: true } }));
+			try {
+				const cfg = await loadConfig(file);
+				assert.strictEqual(cfg.setup?.vscodeVersion, 'max');
+				assert.strictEqual(cfg.setup?.type, 'insider');
+				assert.strictEqual(cfg.setup?.installDependencies, true);
+			} finally {
+				fs.rmSync(dir, { recursive: true });
+			}
+		});
+
+		it('resolves relative paths in each file against that file own directory', async () => {
+			const { dir, file } = makeTmpConfig(JSON.stringify({ extends: './shared/base.json', run: { settings: './settings.json' } }));
+			writeExtraConfig(
+				dir,
+				path.join('shared', 'base.json'),
+				JSON.stringify({ setup: { storage: './base-storage' }, run: { testFiles: ['./out/**/*.test.js'] } }),
+			);
+			const dirFwd = dir.split(path.sep).join('/');
+			try {
+				const cfg = await loadConfig(file);
+				assert.strictEqual(cfg.setup?.storage, path.resolve(dir, 'shared', 'base-storage'));
+				assert.deepStrictEqual(cfg.run?.testFiles, [`${dirFwd}/shared/out/**/*.test.js`]);
+				assert.strictEqual(cfg.run?.settings, path.resolve(dir, 'settings.json'));
+			} finally {
+				fs.rmSync(dir, { recursive: true });
+			}
+		});
+
+		it('throws a descriptive error on circular extends', async () => {
+			const { dir, file } = makeTmpConfig(JSON.stringify({ extends: './b.json' }));
+			writeExtraConfig(dir, 'b.json', JSON.stringify({ extends: './extester.config.json' }));
+			try {
+				await assert.rejects(
+					() => loadConfig(file),
+					(err: Error) => {
+						assert.ok(err instanceof Error);
+						assert.ok(err.message.includes('circular extends'));
+						assert.ok(err.message.includes('extester.config.json'));
+						assert.ok(err.message.includes('b.json'));
+						return true;
+					},
+				);
+			} finally {
+				fs.rmSync(dir, { recursive: true });
+			}
+		});
+
+		it('throws on a config extending itself', async () => {
+			const { dir, file } = makeTmpConfig(JSON.stringify({ extends: './extester.config.json' }));
+			try {
+				await assert.rejects(
+					() => loadConfig(file),
+					(err: Error) => {
+						assert.ok(err instanceof Error);
+						assert.ok(err.message.includes('circular extends'));
+						return true;
+					},
+				);
+			} finally {
+				fs.rmSync(dir, { recursive: true });
+			}
+		});
+
+		it('throws a descriptive error when an extended file does not exist', async () => {
+			const { dir, file } = makeTmpConfig(JSON.stringify({ extends: './does-not-exist.json' }));
+			try {
+				await assert.rejects(
+					() => loadConfig(file),
+					(err: Error) => {
+						assert.ok(err instanceof Error);
+						assert.ok(err.message.includes('extended config file not found'));
+						assert.ok(err.message.includes(path.join(dir, 'does-not-exist.json')));
+						return true;
+					},
+				);
+			} finally {
+				fs.rmSync(dir, { recursive: true });
+			}
+		});
+
+		it('throws when an extended file is not a .json file', async () => {
+			const { dir, file } = makeTmpConfig(JSON.stringify({ extends: './base.txt' }));
+			writeExtraConfig(dir, 'base.txt', JSON.stringify({ setup: { vscodeVersion: '1.131.0' } }));
+			try {
+				await assert.rejects(
+					() => loadConfig(file),
+					(err: Error) => {
+						assert.ok(err instanceof Error);
+						assert.ok(err.message.includes('.json'));
+						return true;
+					},
+				);
+			} finally {
+				fs.rmSync(dir, { recursive: true });
+			}
+		});
+
+		it('names the base file when it contains invalid JSON', async () => {
+			const { dir, file } = makeTmpConfig(JSON.stringify({ extends: './base.json' }));
+			const baseFile = writeExtraConfig(dir, 'base.json', '{bad json}');
+			try {
+				await assert.rejects(
+					() => loadConfig(file),
+					(err: Error) => {
+						assert.ok(err instanceof Error);
+						assert.ok(err.message.includes('invalid JSON'));
+						assert.ok(err.message.includes(baseFile));
+						return true;
+					},
+				);
+			} finally {
+				fs.rmSync(dir, { recursive: true });
+			}
+		});
+
+		it('throws when extends is neither a string nor an array of strings', async () => {
+			const { dir, file } = makeTmpConfig(JSON.stringify({ extends: 42 }));
+			try {
+				await assert.rejects(
+					() => loadConfig(file),
+					(err: Error) => {
+						assert.ok(err instanceof Error);
+						assert.ok(err.message.includes('extends'));
+						return true;
+					},
+				);
+			} finally {
+				fs.rmSync(dir, { recursive: true });
+			}
+		});
+
+		it('supports absolute paths in extends', async () => {
+			const { dir, file: entry } = makeTmpConfig('{}');
+			const baseFile = writeExtraConfig(dir, 'abs-base.json', JSON.stringify({ setup: { vscodeVersion: '1.131.0' } }));
+			fs.writeFileSync(entry, JSON.stringify({ extends: baseFile }), 'utf8');
+			try {
+				const cfg = await loadConfig(entry);
+				assert.strictEqual(cfg.setup?.vscodeVersion, '1.131.0');
+			} finally {
+				fs.rmSync(dir, { recursive: true });
+			}
+		});
+
+		it('loads diamond-shaped extends without a false circular error', async () => {
+			const { dir, file } = makeTmpConfig(JSON.stringify({ extends: ['./b.json', './c.json'] }));
+			writeExtraConfig(dir, 'b.json', JSON.stringify({ extends: './shared.json', run: { cleanup: true } }));
+			writeExtraConfig(dir, 'c.json', JSON.stringify({ extends: './shared.json', run: { offline: true } }));
+			writeExtraConfig(dir, 'shared.json', JSON.stringify({ setup: { vscodeVersion: '1.131.0' } }));
+			try {
+				const cfg = await loadConfig(file);
+				assert.strictEqual(cfg.setup?.vscodeVersion, '1.131.0');
+				assert.strictEqual(cfg.run?.cleanup, true);
+				assert.strictEqual(cfg.run?.offline, true);
+			} finally {
+				fs.rmSync(dir, { recursive: true });
+			}
+		});
+
+		it('does not pollute Object.prototype through merged configs', async () => {
+			const { dir, file } = makeTmpConfig(JSON.stringify({ extends: './base.json' }));
+			writeExtraConfig(dir, 'base.json', '{"__proto__": {"polluted": true}, "setup": {"vscodeVersion": "1.131.0"}}');
+			try {
+				const cfg = await loadConfig(file);
+				// Inheritance still works…
+				assert.strictEqual(cfg.setup?.vscodeVersion, '1.131.0');
+				// …but the malicious key must not reach Object.prototype.
+				assert.strictEqual(({} as Record<string, unknown>).polluted, undefined);
+			} finally {
+				fs.rmSync(dir, { recursive: true });
 			}
 		});
 	});


### PR DESCRIPTION
## What does this PR do?

Adds a top-level `extends` field to `extester.config.json`, so a config file can inherit from one or more base config files — the same way `tsconfig.json` inheritance works. This lets users keep one shared base config (e.g. at a monorepo root) and have per-package configs override only what differs, such as the `run.testFiles` globs.

```json
{
  "extends": "../../extester.base.json",
  "run": { "testFiles": ["./out/test/**/*.test.js"] }
}
```

### Semantics

- `extends` accepts a single path or an array of paths (relative or absolute, `.json` only). Relative targets resolve against the directory of the file that declares them.
- With multiple bases, later entries override earlier ones; the extending file overrides all bases.
- Objects are deep-merged; **arrays and scalars are replaced whole** (predictable overriding, matching tsconfig).
- Relative paths *inside* each config file resolve against that file's own directory, so a base config's `storage`/`testFiles` stay anchored to the base file's location.
- Chains are allowed; circular extends fail with the full chain in the error message. Diamond-shaped inheritance works.
- `extends` never appears in the effective config, so CLI merging in `cli.ts` is untouched.

Extends targets are canonicalised (`realpathSync`) and must be `.json`, but are deliberately not restricted to cwd/tmpdir like `--config` input — the specifier comes from a config file the user already owns, and the primary use case is a shared base *above* the package directory. The existing `safeConfigPath` gate for CLI input is unchanged.

Also updates the JSON schema (`extester.schema.json`) so editor validation/autocomplete accepts `extends`, and documents the feature in `docs/Test-Setup.md`.

### Tests

16 new unit tests in `config.test.ts` covering inheritance, override semantics (scalar/object/array), multi-base ordering, chains, per-file path anchoring, circular/self/diamond extends, missing/non-json/invalid-JSON bases, wrong-type `extends`, absolute paths, and prototype-pollution safety. `npm run test:unit`: 40 passing.

## Checklist

- [x] **CONSIDER** adding a new test if your PR resolves an issue.
- [x] **DO** keep pull requests small so they can be easily reviewed.
- [x] **DO** make sure tests pass.
- [x] **DO** make sure any public APIs changes are documented.
- [x] **DO** make sure not to introduce any compiler warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)