### PR TITLE
fix: testing stack P1 hardening (download retry, windowTypes, engines, selenium 4.48)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1858,6 +1858,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -2824,6 +2825,7 @@
       "integrity": "sha512-fHq2VC1kpyYfvEcbiMjOpySY4WS7voEp89yAThrHRX5sm9j2lzYppCb2umFMEed4fWcyeLjHxrz0mpjNBaBxMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.68.0",
         "@typescript-eslint/types": "8.68.0",
@@ -3648,6 +3650,7 @@
       "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5752,6 +5755,7 @@
       "integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -5811,6 +5815,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -9238,6 +9243,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.4.5",
         "@emnapi/runtime": "1.4.5",
@@ -10405,6 +10411,7 @@
       "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -11171,9 +11178,9 @@
       }
     },
     "node_modules/selenium-webdriver": {
-      "version": "4.47.0",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.47.0.tgz",
-      "integrity": "sha512-nxxJnH25tsJxz+pdMxtvH89tbrMnfff6W//uBIVlOWz1KZlADiQ7dyRPehknKdYiC3HwEypTy1l+tozxO0I2Qw==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.48.0.tgz",
+      "integrity": "sha512-rKM9uXFRWcF9aThrZQDNQH2/9Et/WvMZbg3/x1rnSYWoXiwJuShYeH0IAli8Cuw+c3lEV0UWPfUz88H+fvW9Hg==",
       "funding": [
         {
           "type": "github",
@@ -11185,6 +11192,7 @@
         }
       ],
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@bazel/runfiles": "^6.5.0",
         "jszip": "^3.10.1",
@@ -12324,6 +12332,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13091,7 +13100,7 @@
         "hpagent": "^1.2.0",
         "js-yaml": "^5.3.0",
         "sanitize-filename": "^1.6.4",
-        "selenium-webdriver": "^4.47.0",
+        "selenium-webdriver": "^4.48.0",
         "targz": "^1.0.1",
         "unzipper": "^0.12.5"
       },
@@ -13101,6 +13110,9 @@
       "devDependencies": {
         "@types/unzipper": "^0.10.11",
         "mocha": "^11.7.6"
+      },
+      "engines": {
+        "node": ">=22"
       },
       "peerDependencies": {
         "mocha": ">=5.2.0",
@@ -13733,35 +13745,16 @@
         "node": ">=20"
       }
     },
-    "packages/extester/node_modules/js-yaml": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.3.0.tgz",
-      "integrity": "sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.mjs"
-      }
-    },
     "packages/locators": {
       "name": "@redhat-developer/locators",
       "version": "1.21.0",
       "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22"
+      },
       "peerDependencies": {
         "@redhat-developer/page-objects": ">=1.0.0",
-        "selenium-webdriver": "^4.47.0"
+        "selenium-webdriver": "^4.48.0"
       }
     },
     "packages/page-objects": {
@@ -13774,8 +13767,11 @@
         "compare-versions": "^6.1.1",
         "fs-extra": "^11.4.0"
       },
+      "engines": {
+        "node": ">=22"
+      },
       "peerDependencies": {
-        "selenium-webdriver": "^4.47.0",
+        "selenium-webdriver": "^4.48.0",
         "typescript": ">=4.6.2"
       }
     },

--- a/packages/extester/package.json
+++ b/packages/extester/package.json
@@ -74,7 +74,7 @@
     "hpagent": "^1.2.0",
     "js-yaml": "^5.3.0",
     "sanitize-filename": "^1.6.4",
-    "selenium-webdriver": "^4.47.0",
+    "selenium-webdriver": "^4.48.0",
     "targz": "^1.0.1",
     "unzipper": "^0.12.5"
   },

--- a/packages/extester/package.json
+++ b/packages/extester/package.json
@@ -23,6 +23,9 @@
   },
   "author": "Red Hat",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=22"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extester/src/browser.ts
+++ b/packages/extester/src/browser.ts
@@ -182,9 +182,10 @@ export class VSBrowser {
 		}
 
 		const extraArgs = ['--skip-welcome', '--skip-sessions-welcome', '--skip-release-notes'];
-		let options = new Options().setChromeBinaryPath(codePath).addArguments(...args, ...extraArgs) as any;
-		options['options_'].windowTypes = ['webview'];
-		options = options as Options;
+		const options = new Options()
+			.setChromeBinaryPath(codePath)
+			.addArguments(...args, ...extraArgs)
+			.windowTypes('webview') as Options;
 
 		const prefs = new logging.Preferences();
 		prefs.setLevel(logging.Type.DRIVER, this.logLevel);

--- a/packages/extester/src/test/download.test.ts
+++ b/packages/extester/src/test/download.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License", destination); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import assert from 'assert';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import { AddressInfo } from 'net';
+import { Download } from '../util/download';
+
+describe('Download.getFile', function () {
+	// got's exponential backoff makes the first retry fire after ~1s
+	this.timeout(20000);
+
+	let server: http.Server;
+	let baseUrl: string;
+	let requestCount: number;
+	let handler: (req: http.IncomingMessage, res: http.ServerResponse) => void;
+	let workDir: string;
+
+	const FULL_BODY = Buffer.from('0123456789'.repeat(1000));
+
+	beforeEach(async () => {
+		requestCount = 0;
+		server = http.createServer((req, res) => {
+			requestCount++;
+			handler(req, res);
+		});
+		await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+		baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+		workDir = await fs.mkdtemp(path.join(os.tmpdir(), 'extest-download-test-'));
+	});
+
+	afterEach(async () => {
+		await new Promise<void>((resolve) => server.close(() => resolve()));
+		await fs.remove(workDir);
+	});
+
+	it('downloads a file to the destination', async () => {
+		handler = (_req, res) => {
+			res.writeHead(200, { 'Content-Length': FULL_BODY.length });
+			res.end(FULL_BODY);
+		};
+		const destination = path.join(workDir, 'ok.bin');
+
+		await Download.getFile(`${baseUrl}/ok.bin`, destination);
+
+		assert.ok(Buffer.compare(await fs.readFile(destination), FULL_BODY) === 0, 'downloaded content differs from served content');
+	});
+
+	it('retries an interrupted download and writes the complete file', async () => {
+		handler = (_req, res) => {
+			if (requestCount === 1) {
+				// advertise the full length but cut the connection halfway through
+				res.writeHead(200, { 'Content-Length': FULL_BODY.length });
+				res.write(FULL_BODY.subarray(0, FULL_BODY.length / 2));
+				res.destroy();
+			} else {
+				res.writeHead(200, { 'Content-Length': FULL_BODY.length });
+				res.end(FULL_BODY);
+			}
+		};
+		const destination = path.join(workDir, 'retried.bin');
+
+		await Download.getFile(`${baseUrl}/retried.bin`, destination);
+
+		assert.strictEqual(requestCount, 2, 'expected the interrupted download to be retried exactly once');
+		assert.ok(Buffer.compare(await fs.readFile(destination), FULL_BODY) === 0, 'file content after retry differs from served content');
+	});
+
+	it('rejects on a non-retriable error and leaves no partial files behind', async () => {
+		handler = (_req, res) => {
+			res.writeHead(404);
+			res.end('not here');
+		};
+		const destination = path.join(workDir, 'missing.bin');
+
+		await assert.rejects(Download.getFile(`${baseUrl}/missing.bin`, destination));
+
+		assert.strictEqual(requestCount, 1, '404 must not be retried');
+		assert.ok(!(await fs.pathExists(destination)), 'destination must not exist after a failed download');
+		assert.ok(!(await fs.pathExists(`${destination}.tmp`)), 'temp file must be cleaned up after a failed download');
+	});
+});

--- a/packages/extester/src/util/download.ts
+++ b/packages/extester/src/util/download.ts
@@ -16,7 +16,6 @@
  */
 
 import * as fs from 'fs-extra';
-import { promisify } from 'node:util';
 import stream from 'node:stream';
 import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
 
@@ -113,23 +112,42 @@ export class Download {
 		const tmpDest = `${destination}.tmp`;
 		let lastTick = 0;
 		const got = (await import('got')).default;
-		const dlStream = got.stream(uri, options);
-		dlStream.on('retry', (newRetryCount: number, error) => {
-			console.warn(`retry(${newRetryCount}): Failed getting ${uri} due to ${error}`);
-		});
-		if (progress) {
-			dlStream.on('downloadProgress', ({ transferred, total, percent }) => {
-				const currentTime = Date.now();
-				if (total > 0 && (lastTick === 0 || transferred === total || currentTime - lastTick >= 2000)) {
-					console.log(`progress: ${transferred}/${total} (${Math.floor(100 * percent)}%)`);
-					lastTick = currentTime;
-				}
-			});
-		}
-		const writeStream = fs.createWriteStream(tmpDest);
+		type GotStream = ReturnType<typeof got.stream>;
 
 		try {
-			await promisify(stream.pipeline)(dlStream, writeStream);
+			await new Promise<void>((resolve, reject) => {
+				// got never retries streams on its own: on a retriable failure it only emits
+				// 'retry' and expects the consumer to continue with a fresh stream obtained
+				// from createRetryStream(), so every attempt re-pipes into a truncated tmp file.
+				const attempt = (dlStream: GotStream): void => {
+					let retrying = false;
+					dlStream.once('retry', (newRetryCount: number, error: unknown, createRetryStream: () => GotStream) => {
+						retrying = true;
+						console.warn(`retry(${newRetryCount}): Failed getting ${uri} due to ${error}`);
+						attempt(createRetryStream());
+					});
+					if (progress) {
+						dlStream.on('downloadProgress', ({ transferred, total, percent }) => {
+							const currentTime = Date.now();
+							if (total > 0 && (lastTick === 0 || transferred === total || currentTime - lastTick >= 2000)) {
+								console.log(`progress: ${transferred}/${total} (${Math.floor(100 * percent)}%)`);
+								lastTick = currentTime;
+							}
+						});
+					}
+					stream.pipeline(dlStream, fs.createWriteStream(tmpDest), (err) => {
+						if (err) {
+							// when a retry fired, the next attempt's pipeline settles the promise
+							if (!retrying) {
+								reject(err);
+							}
+						} else {
+							resolve();
+						}
+					});
+				};
+				attempt(got.stream(uri, options));
+			});
 			await fs.rename(tmpDest, destination);
 		} catch (err) {
 			await fs.remove(tmpDest).catch(() => {});

--- a/packages/locators/package.json
+++ b/packages/locators/package.json
@@ -10,6 +10,9 @@
   ],
   "author": "Red Hat",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=22"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/locators/package.json
+++ b/packages/locators/package.json
@@ -41,6 +41,6 @@
   },
   "peerDependencies": {
     "@redhat-developer/page-objects": ">=1.0.0",
-    "selenium-webdriver": "^4.47.0"
+    "selenium-webdriver": "^4.48.0"
   }
 }

--- a/packages/page-objects/package.json
+++ b/packages/page-objects/package.json
@@ -46,7 +46,7 @@
     "fs-extra": "^11.4.0"
   },
   "peerDependencies": {
-    "selenium-webdriver": "^4.47.0",
+    "selenium-webdriver": "^4.48.0",
     "typescript": ">=4.6.2"
   }
 }

--- a/packages/page-objects/package.json
+++ b/packages/page-objects/package.json
@@ -17,6 +17,9 @@
   },
   "author": "Red Hat",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=22"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/page-objects/src/components/editor/EditorView.ts
+++ b/packages/page-objects/src/components/editor/EditorView.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { error, WebElement } from 'selenium-webdriver';
+import { error, Key, WebElement } from 'selenium-webdriver';
 import { TextEditor } from '../..';
 import { AbstractElement } from '../AbstractElement';
 import { ElementWithContextMenu } from '../ElementWithContextMenu';
@@ -316,7 +316,7 @@ export class EditorGroup extends AbstractElement {
 			titles = await this.getOpenEditorTitles();
 			if (titles.length >= previousCount) {
 				try {
-					await this.getDriver().actions().sendKeys('\uE00C').perform();
+					await this.getDriver().actions().sendKeys(Key.ESCAPE).perform();
 					await this.getWaitHelper().sleep(500);
 				} catch {
 					/* ignore */


### PR DESCRIPTION
## What

Five independently-scoped hardening fixes that came out of an internal analysis of ExTester's selenium / ChromeDriver / Electron / VS Code CLI usage. One conventionally-titled commit per change, rebased on latest `main`.

| Commit | Change |
|---|---|
| `fix(extester)` | **Actually retry interrupted archive downloads** — got never retries streams on its own; it emits `retry` and expects the consumer to continue with a fresh stream from `createRetryStream()`. The old handler only logged, so the 5-attempt retry policy (incl. `ERR_HTTP_CONTENT_LENGTH_MISMATCH`, added for flaky CI downloads) never applied to the archive path. Covered by new unit tests (interrupted→retried→complete file; 404 not retried; tmp cleanup). |
| `refactor(extester)` | **Public `Options.windowTypes('webview')`** instead of the `as any` poke of selenium's private `options_` field. Serialized capabilities verified byte-identical. |
| `build` | **Declare `engines.node >=22`** in the three published packages — selenium-webdriver and got both require Node ≥ 22, so installs on older Node fail at runtime today; engines makes npm surface the incompatibility at install time. |
| `fix(page-objects)` | **`Key.ESCAPE`** instead of the raw `''` codepoint (identical value, named constant). |
| `build(deps)` | **selenium-webdriver 4.47.0 → 4.48.0** (CDP v150–152, BiDi internals; nothing affecting classic-session usage). Same scope as the previous dependabot bump: deps + peer ranges + lockfile. |

## Testing

- Unit tests: 43/43 passing after rebase on latest main (includes 3 new `Download.getFile` tests written TDD-style — the retry test failed against the old implementation with the exact diagnosed error, `retry(1)` + `ERR_STREAM_PREMATURE_CLOSE`).
- UI smoke: `test:webview` group 22/22 against real VS Code 1.131.0 on macOS — exercises the refactored `windowTypes` attach path end-to-end on selenium 4.48.0.
- All packages compile + lint clean; lockfile re-verified stable after rebase.

Note for review: commits are individually scoped — a merge commit or rebase-merge preserves that mapping if preferred over squash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
