### PR TITLE
feat(extester): adopt Microsoft-harness launch flags and collect crash dumps

### DIFF
--- a/.github/workflows/template-main.yaml
+++ b/.github/workflows/template-main.yaml
@@ -93,6 +93,7 @@ jobs:
           path: |
             ${{ runner.temp }}/test-resources/screenshots/**/*.png
             ${{ runner.temp }}/test-resources/chromedriver.log
+            ${{ runner.temp }}/test-resources/crashes/**
 
       - name: 💾 Upload Screenshots
         uses: actions/upload-artifact@v7
@@ -102,3 +103,4 @@ jobs:
           path: |
             ${{ runner.temp }}/test-resources/screenshots/**/*.png
             ${{ runner.temp }}/test-resources/chromedriver.log
+            ${{ runner.temp }}/test-resources/crashes/**

--- a/.github/workflows/template-suite.yaml
+++ b/.github/workflows/template-suite.yaml
@@ -92,3 +92,4 @@ jobs:
           path: |
             ${{ runner.temp }}/test-resources/screenshots/**/*.png
             ${{ runner.temp }}/test-resources/chromedriver.log
+            ${{ runner.temp }}/test-resources/crashes/**

--- a/packages/extester/src/browser.ts
+++ b/packages/extester/src/browser.ts
@@ -154,7 +154,28 @@ export class VSBrowser {
 			console.log(`Restored languagepacks.json to ${languagePacksPath}`);
 		}
 
-		const args = ['--no-sandbox', '--disable-dev-shm-usage', `--user-data-dir=${path.join(this.storagePath, 'settings')}`];
+		// Crash dumps are redirected into the storage folder so CI can collect
+		// them as failure artifacts alongside screenshots and driver logs.
+		const crashesDir = path.join(this.storagePath, 'crashes');
+		fs.mkdirpSync(crashesDir);
+
+		const args = [
+			'--no-sandbox',
+			'--disable-dev-shm-usage',
+			// Determinism flags used by Microsoft's own harnesses (@vscode/test-electron
+			// and the VS Code smoke tests): the updater, experiments and telemetry must
+			// not vary behavior mid-run, and workspace trust has to be off from the very
+			// first window - the injected settings.json only applies after the profile
+			// is read, while the flag applies immediately.
+			'--disable-updates',
+			'--disable-workspace-trust',
+			'--disable-telemetry',
+			'--disable-experiments',
+			'--no-cached-data',
+			'--disable-gpu-sandbox',
+			`--crash-reporter-directory=${crashesDir}`,
+			`--user-data-dir=${path.join(this.storagePath, 'settings')}`,
+		];
 
 		if (this.locale) {
 			args.push(`--locale=${this.locale}`);


### PR DESCRIPTION
## What

Launch VS Code with the determinism flags Microsoft's own test harnesses pass, and collect crash dumps as CI artifacts. (Backlog item B9 from the internal testing-stack analysis; follows #2469/#2470.)

**Added flags** (verbatim from `@vscode/test-electron`'s `runTests` defaults and `microsoft/vscode` smoke tests, all accepted VS Code CLI options):

- `--disable-updates`, `--disable-workspace-trust` — ExTester already covers these via injected settings, but settings only apply after the profile is read, while flags apply from the very first window ([vscode-test#120](https://github.com/microsoft/vscode-test/issues/120))
- `--disable-telemetry`, `--disable-experiments` — no experiment/telemetry variance mid-run (previously uncovered)
- `--no-cached-data` — no stale V8 cache across version switches
- `--disable-gpu-sandbox` — [vscode-test#221](https://github.com/microsoft/vscode-test/issues/221)
- `--crash-reporter-directory=<storage>/crashes` — crash dumps land in the storage folder (the smoke-test approach); the CI failure-artifact uploads now include `crashes/**` alongside screenshots and `chromedriver.log`

**Deliberately not added:** `--disable-gpu` (no first-party precedent; forces software rasterization) and the Chromium background-throttling set (`--disable-renderer-backgrounding` etc. — not VS Code CLI options, and Playwright deliberately doesn't inject them into packaged apps). Those need their own evaluation.

## Testing

- Local UI smoke on macOS / VS Code 1.131.0: webview group 22/22, 01_general green; the crashpad directory structure (`attachments/completed/new/pending`) appears under `<storage>/crashes`, confirming the crash reporter redirection is active.
- Flags are unconditional: on VS Code versions that predate any of them, unknown options are passed through to Electron/Chromium with a console warning by design (`argvHelper.ts`), so behavior below the supported window is unchanged.
- Full 6-combo matrix validation is exactly what this PR's CI run is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
