### PR TITLE
docs: VS Code 1.87+ dropdown limitation is permanent

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 ## Limitations in testing with VS Code 1.87+
 
-The issue [#206897](https://github.com/microsoft/vscode/issues/206897) was spotted and reported in [Visual Studio Code](https://github.com/microsoft/vscode) project. The problem is currently affecting only Windows and Linux architectures. Unfortunately there is no identified workaround at the moment, which leads to some ExTester's components methods are not working properly.
+Since VS Code 1.87, the `title` attribute of dropdown (`<select>`) elements is no longer set on Windows and Linux — VS Code uses custom hovers instead (macOS is not affected). This was reported upstream as [#206897](https://github.com/microsoft/vscode/issues/206897) and **closed as not-planned** in May 2024, so this is a permanent limitation, not a pending fix. The affected methods throw a deprecation error on Windows and Linux:
 
 - Output views / Text views
   - getCurrentChannel


### PR DESCRIPTION
## What

Corrects the "Limitations in testing with VS Code 1.87+" entry in `KNOWN_ISSUES.md`:

- [microsoft/vscode#206897](https://github.com/microsoft/vscode/issues/206897) is the dropdown/select `title`-attribute issue, and it was **closed as not-planned in May 2024** (feature-request triage) — the old wording ("no identified workaround at the moment") implied a fix might still come.
- The entry now names the actual cause (VS Code removed the `title` attribute from `<select>` elements on Windows/Linux in favor of custom hovers; macOS unaffected) and states plainly that `getCurrentChannel` / `getLaunchConfiguration` throwing on Windows/Linux is permanent.

Doc-only change, no code. Follows up the internal testing-stack analysis (upstream-status check, 2026-08-29).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
