### PR TITLE
feat(extester): document all vsce IPackageOptions fields in config schema

### DIFF
--- a/docs/Test-Setup.md
+++ b/docs/Test-Setup.md
@@ -321,6 +321,10 @@ Common examples:
 // Use yarn instead of npm
 { useYarn: true }
 
+// Use yarn without dependency detection (vsce's --yarn --no-dependencies,
+// e.g. for yarn/npm workspaces or fully bundled extensions)
+{ useYarn: true, dependencies: false }
+
 // Recurse into symlinked directories (fixes missing-symlink issues)
 { followSymlinks: true }
 

--- a/packages/extester/resources/extester.schema.json
+++ b/packages/extester/resources/extester.schema.json
@@ -39,37 +39,172 @@
         },
         "packageOptions": {
           "type": "object",
-          "description": "vsce packaging options forwarded directly to vsce.createVSIX(). See @vscode/vsce IPackageOptions for all available fields.",
+          "description": "vsce packaging options forwarded directly to vsce.createVSIX(). Mirrors @vscode/vsce IPackageOptions — any field vsce supports is accepted, even if not listed here.",
           "properties": {
-            "useYarn": {
+            "packagePath": {
+              "type": "string",
+              "description": "Destination path of the packaged .vsix file (vsce: --out). Defaults to <name>-<version>.vsix in the extension directory.",
+              "examples": ["./out/extension.vsix"]
+            },
+            "version": {
+              "type": "string",
+              "description": "Bump the extension to this version before packaging (equivalent to 'vsce package <version>').",
+              "examples": ["1.2.3", "patch", "minor", "major"]
+            },
+            "target": {
+              "type": "string",
+              "description": "Target platform for a platform-specific extension (vsce: --target).",
+              "enum": [
+                "win32-x64",
+                "win32-arm64",
+                "linux-x64",
+                "linux-arm64",
+                "linux-armhf",
+                "darwin-x64",
+                "darwin-arm64",
+                "alpine-x64",
+                "alpine-arm64",
+                "web"
+              ]
+            },
+            "ignoreOtherTargetFolders": {
               "type": "boolean",
-              "description": "Use yarn instead of npm when packaging.",
+              "description": "Ignore files inside folders named after other targets (vsce: --ignore-other-target-folders). Only valid when 'target' is set.",
               "default": false
             },
             "followSymlinks": {
               "type": "boolean",
-              "description": "Follow symlinks when packaging.",
+              "description": "Recurse into symlinked directories instead of treating them as files (vsce: --follow-symlinks).",
               "default": false
+            },
+            "commitMessage": {
+              "type": "string",
+              "description": "Commit message used when calling 'npm version' (vsce: --message). Only applies when 'version' is set."
+            },
+            "gitTagVersion": {
+              "type": "boolean",
+              "description": "Create a version commit and tag when calling 'npm version'. Set to false for vsce --no-git-tag-version. Only applies when 'version' is set.",
+              "default": true
+            },
+            "updatePackageJson": {
+              "type": "boolean",
+              "description": "Update package.json when bumping the version. Set to false for vsce --no-update-package-json. Only applies when 'version' is set.",
+              "default": true
+            },
+            "cwd": {
+              "type": "string",
+              "description": "Directory of the extension to package. Defaults to the current working directory."
+            },
+            "readmePath": {
+              "type": "string",
+              "description": "Path to the README file shown on the marketplace (vsce: --readme-path). Defaults to README.md.",
+              "examples": ["./docs/README.md"]
+            },
+            "changelogPath": {
+              "type": "string",
+              "description": "Path to the CHANGELOG file (vsce: --changelog-path). Defaults to CHANGELOG.md.",
+              "examples": ["./docs/CHANGELOG.md"]
+            },
+            "githubBranch": {
+              "type": "string",
+              "description": "GitHub branch used to infer relative links in README.md (vsce: --githubBranch). Can be overridden by baseContentUrl and baseImagesUrl.",
+              "examples": ["main"]
+            },
+            "gitlabBranch": {
+              "type": "string",
+              "description": "GitLab branch used to infer relative links in README.md (vsce: --gitlabBranch). Can be overridden by baseContentUrl and baseImagesUrl.",
+              "examples": ["main"]
+            },
+            "rewriteRelativeLinks": {
+              "type": "boolean",
+              "description": "Rewrite relative links in README.md into absolute URLs. Set to false for vsce --no-rewrite-relative-links.",
+              "default": true
+            },
+            "baseContentUrl": {
+              "type": "string",
+              "description": "Prepend all relative links in README.md with this URL (vsce: --baseContentUrl)."
+            },
+            "baseImagesUrl": {
+              "type": "string",
+              "description": "Prepend all relative image links in README.md with this URL (vsce: --baseImagesUrl)."
+            },
+            "useYarn": {
+              "type": "boolean",
+              "description": "Use yarn instead of npm when packaging (vsce: --yarn / --no-yarn). When not set, vsce infers it from the presence of yarn.lock or .yarnrc."
+            },
+            "dependencyEntryPoints": {
+              "type": "array",
+              "description": "Select packages that should be included when packaging (vsce: --packagedDependencies).",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ignoreFile": {
+              "type": "string",
+              "description": "Path to an alternative .vscodeignore file (vsce: --ignoreFile).",
+              "examples": ["./.vscodeignore-test"]
+            },
+            "gitHubIssueLinking": {
+              "type": "boolean",
+              "description": "Automatically expand GitHub-style issue syntax (#123) into links in README.md. Set to false for vsce --no-gitHubIssueLinking.",
+              "default": true
+            },
+            "gitLabIssueLinking": {
+              "type": "boolean",
+              "description": "Automatically expand GitLab-style issue syntax into links in README.md. Set to false for vsce --no-gitLabIssueLinking.",
+              "default": true
+            },
+            "dependencies": {
+              "type": "boolean",
+              "description": "Detect and include npm/yarn dependencies in the package. Set to false for the vsce --no-dependencies flag — typically needed together with useYarn, for yarn/npm workspaces, or when the extension is fully bundled.",
+              "default": true
             },
             "preRelease": {
               "type": "boolean",
-              "description": "Mark the packaged extension as a pre-release.",
+              "description": "Mark the packaged extension as a pre-release (vsce: --pre-release).",
               "default": false
             },
             "allowStarActivation": {
               "type": "boolean",
-              "description": "Allow the use of * in activationEvents.",
+              "description": "Allow the use of * in activationEvents (vsce: --allow-star-activation).",
               "default": false
             },
             "allowMissingRepository": {
               "type": "boolean",
-              "description": "Skip the check for a repository field in package.json.",
+              "description": "Skip the check for a repository field in package.json (vsce: --allow-missing-repository).",
+              "default": false
+            },
+            "allowUnusedFilesPattern": {
+              "type": "boolean",
+              "description": "Allow 'files' patterns in package.json that match no files (vsce: --allow-unused-files-pattern).",
+              "default": false
+            },
+            "allowPackageSecrets": {
+              "type": "array",
+              "description": "Allow packaging specific kinds of detected secrets (vsce: --allow-package-secrets). Secret names are reported in the packaging error message.",
+              "items": {
+                "type": "string"
+              },
+              "examples": [["npm"]]
+            },
+            "allowPackageAllSecrets": {
+              "type": "boolean",
+              "description": "Allow packaging even when secrets are detected (vsce: --allow-package-all-secrets).",
+              "default": false
+            },
+            "allowPackageEnvFile": {
+              "type": "boolean",
+              "description": "Allow packaging .env files (vsce: --allow-package-env-file).",
               "default": false
             },
             "skipLicense": {
               "type": "boolean",
-              "description": "Skip adding a LICENSE file to the package.",
+              "description": "Skip adding a LICENSE file to the package (vsce: --skip-license).",
               "default": false
+            },
+            "signTool": {
+              "type": "string",
+              "description": "Path to a VSIX signing tool (vsce: --sign-tool). Invoked with the signature manifest and .p7s file as arguments."
             }
           },
           "additionalProperties": true

--- a/packages/extester/src/test/schema.test.ts
+++ b/packages/extester/src/test/schema.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License", destination); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { IPackageOptions } from '@vscode/vsce';
+import assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Compile-time-complete list of `IPackageOptions` keys from `@vscode/vsce`.
+ * The `Record<keyof ...>` type forces this object to name every field exactly once,
+ * so a vsce upgrade that adds or removes fields fails compilation here — update
+ * this list and `resources/extester.schema.json` together.
+ */
+const PACKAGE_OPTIONS_KEYS: Record<keyof Required<IPackageOptions>, true> = {
+	packagePath: true,
+	version: true,
+	target: true,
+	ignoreOtherTargetFolders: true,
+	followSymlinks: true,
+	commitMessage: true,
+	gitTagVersion: true,
+	updatePackageJson: true,
+	cwd: true,
+	readmePath: true,
+	changelogPath: true,
+	githubBranch: true,
+	gitlabBranch: true,
+	rewriteRelativeLinks: true,
+	baseContentUrl: true,
+	baseImagesUrl: true,
+	useYarn: true,
+	dependencyEntryPoints: true,
+	ignoreFile: true,
+	gitHubIssueLinking: true,
+	gitLabIssueLinking: true,
+	dependencies: true,
+	preRelease: true,
+	allowStarActivation: true,
+	allowMissingRepository: true,
+	allowUnusedFilesPattern: true,
+	allowPackageSecrets: true,
+	allowPackageAllSecrets: true,
+	allowPackageEnvFile: true,
+	skipLicense: true,
+	signTool: true,
+};
+
+describe('extester.schema.json', () => {
+	// out/test → out → package root → resources
+	const schemaPath = path.resolve(__dirname, '..', '..', 'resources', 'extester.schema.json');
+	const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+	const schemaPackageOptions: Record<string, unknown> = schema.properties.setup.properties.packageOptions.properties;
+
+	it('documents every IPackageOptions field of @vscode/vsce in setup.packageOptions', () => {
+		const missing = Object.keys(PACKAGE_OPTIONS_KEYS).filter((key) => !(key in schemaPackageOptions));
+		assert.deepStrictEqual(missing, [], `schema is missing packageOptions fields: ${missing.join(', ')}`);
+	});
+
+	it('documents only fields that exist on IPackageOptions in setup.packageOptions', () => {
+		const unknown = Object.keys(schemaPackageOptions).filter((key) => !(key in PACKAGE_OPTIONS_KEYS));
+		assert.deepStrictEqual(unknown, [], `schema documents unknown packageOptions fields: ${unknown.join(', ')}`);
+	});
+
+	it('keeps packageOptions open for future vsce fields (additionalProperties: true)', () => {
+		assert.strictEqual(schema.properties.setup.properties.packageOptions.additionalProperties, true);
+	});
+});


### PR DESCRIPTION
## What

Expands the `extester.config.json` schema so `setup.packageOptions` documents the **complete** `IPackageOptions` surface of `@vscode/vsce` 3.9.2 — all 31 fields, up from 6.

`packageOptions` is typed as vsce's own `IPackageOptions` and forwarded verbatim to `vsce.createVSIX()`, so every option already worked at runtime — but only 6 were discoverable via IDE autocompletion. Notably missing was `dependencies: false` (the `--no-dependencies` flag), which is commonly needed together with `useYarn` for yarn/npm workspaces or fully bundled extensions.

## Changes

- **`extester.schema.json`** — adds the 25 missing fields (`packagePath`, `version`, `target` as an enum of vsce's valid platforms, `dependencies`, `ignoreFile`, `readmePath`, `changelogPath`, secrets allowances, `signTool`, …) with descriptions mapped to their vsce CLI flags and actual defaults. Also fixes the `useYarn` description: vsce infers its default from `yarn.lock`/`.yarnrc`, it is not simply `false`. `additionalProperties: true` is kept so future vsce fields keep working before the schema catches up.
- **`schema.test.ts`** (new) — sync-guard test: a `Record<keyof IPackageOptions, true>` fails **compilation** when a vsce upgrade adds or removes fields, and runtime assertions verify the schema documents exactly that key set, so the schema cannot silently drift from vsce again.
- **`Test-Setup.md`** — adds a `{ useYarn: true, dependencies: false }` example to the `packageOptions` section.

## Verification

- All 27 extester unit tests pass (`npm run test:unit`), including the 3 new schema tests (written test-first; they failed against the old 6-field schema).
- Validated with ajv: the schema compiles, the config template and both test-project configs still validate, a `useYarn` + `dependencies: false` config validates, and an invalid `target` is correctly rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)