### PR TITLE
fix(page-objects): discard dirty editors in closeAllEditors to prevent modal cascade

### DIFF
--- a/packages/page-objects/src/components/editor/EditorView.ts
+++ b/packages/page-objects/src/components/editor/EditorView.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { error, Key, WebElement } from 'selenium-webdriver';
+import { error, Key, until, WebElement } from 'selenium-webdriver';
 import { TextEditor } from '../..';
 import { AbstractElement } from '../AbstractElement';
 import { ElementWithContextMenu } from '../ElementWithContextMenu';
@@ -24,6 +24,7 @@ import { Editor } from './Editor';
 import { EditorAction, EditorActionDropdown } from './EditorAction';
 import { SettingsEditor } from './SettingsEditor';
 import { WebView } from './WebView';
+import { ModalDialog } from '../dialog/ModalDialog';
 
 export class EditorTabNotFound extends Error {
 	constructor(title: string, group: number) {
@@ -315,17 +316,48 @@ export class EditorGroup extends AbstractElement {
 			}
 			titles = await this.getOpenEditorTitles();
 			if (titles.length >= previousCount) {
-				try {
-					await this.getDriver().actions().sendKeys(Key.ESCAPE).perform();
-					await this.getWaitHelper().sleep(500);
-				} catch {
-					/* ignore */
+				// The tab did not close: a dirty editor raises a "save changes?" modal
+				// that blocks the close. Discard the changes so the editor actually
+				// closes — otherwise the modal is left intercepting every subsequent
+				// click and cascades the rest of the suite into failure. Fall back to
+				// Escape (which cancels the modal) if the dialog cannot be handled.
+				if (!(await this.discardDirtyEditorDialog())) {
+					try {
+						await this.getDriver().actions().sendKeys(Key.ESCAPE).perform();
+					} catch {
+						/* ignore */
+					}
 				}
+				await this.getWaitHelper().sleep(500);
 				titles = await this.getOpenEditorTitles();
 				if (titles.length >= previousCount) {
 					break;
 				}
 			}
+		}
+	}
+
+	/**
+	 * If a "save changes?" modal dialog is currently blocking the workbench,
+	 * dismiss it by discarding the changes ("Don't Save") so the underlying
+	 * dirty editor closes. Returns true when a dialog was found and handled.
+	 */
+	private async discardDirtyEditorDialog(): Promise<boolean> {
+		const dialogs = await this.getDriver().findElements(EditorView.locators.Dialog.constructor);
+		if (dialogs.length === 0) {
+			return false;
+		}
+		try {
+			const dialog = new ModalDialog();
+			await dialog.pushButton(`Don't Save`);
+			await this.getDriver()
+				.wait(until.stalenessOf(dialogs[0]), 5000)
+				.catch(() => {
+					/* dialog may already be gone */
+				});
+			return true;
+		} catch {
+			return false;
 		}
 	}
 

--- a/tests/test-project/src/test/editor/editorViewCleanup.test.ts
+++ b/tests/test-project/src/test/editor/editorViewCleanup.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License", destination); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { By, EditorView, InputBox, TextEditor, VSBrowser, Workbench, until } from 'vscode-extension-tester';
+
+// Regression guard: a dirty editor makes VS Code raise a modal "save changes?"
+// dialog when the tab is closed. closeAllEditors() must discard those changes so
+// the editor actually closes and no leftover modal is left to intercept clicks in
+// subsequent tests (which otherwise cascades an entire suite into failure).
+describe('EditorView.closeAllEditors with a dirty editor', function () {
+	this.timeout(60000);
+
+	beforeEach(async function () {
+		await new EditorView().closeAllEditors();
+		await new Workbench().executeCommand('Create: New File...');
+		await (await InputBox.create(10000)).selectQuickPick('Text File');
+		await VSBrowser.instance.driver.wait(until.elementLocated(By.className('monaco-editor')), 10000, 'Text editor did not become active');
+		const editor = new TextEditor();
+		await editor.typeTextAt(1, 1, 'unsaved content');
+		await VSBrowser.instance.driver.wait(
+			async () => {
+				try {
+					return await editor.isDirty();
+				} catch {
+					return false;
+				}
+			},
+			5000,
+			'Editor did not become dirty after typing',
+		);
+	});
+
+	afterEach(async function () {
+		// Make sure a failed run cannot leak a modal into the rest of the suite.
+		await new EditorView().closeAllEditors();
+	});
+
+	it('closes the dirty editor and leaves no blocking modal dialog', async function () {
+		await new EditorView().closeAllEditors();
+
+		const remaining = await new EditorView().getOpenEditorTitles();
+		expect(remaining, 'a dirty editor was left open after closeAllEditors').to.have.lengthOf(0);
+
+		const modals = await VSBrowser.instance.driver.findElements(By.className('monaco-dialog-modal-block'));
+		expect(modals, 'a save-changes modal was left blocking the workbench').to.have.lengthOf(0);
+	});
+});


### PR DESCRIPTION
## What

Hardens `EditorView.closeAllEditors()` so a **dirty editor cannot leak a blocking modal dialog into the rest of a test suite** — a real cascade amplifier behind several of the recent CI red groups.

### The mechanism (traced from CI artifacts)

A failing `menu` job's screenshot showed the workbench frozen behind a modal:

> *"Do you want to save the changes you made to settings.json? Your changes will be lost if you don't save them."* — Save / Don't Save / Cancel

With `files.simpleDialog.enable` on (as it is for tests), that dialog is a DOM overlay (`.monaco-dialog-modal-block`) that intercepts **every** subsequent click. The chromedriver logs showed exactly that: a cascade of `element click intercepted: … Other element would receive the click: <div class="monaco-dialog-modal-block dimmed">`, turning one dirty editor into `0 passing, N failing` for the whole group.

The root of the leak: `closeAllEditors()` handled the save-prompt by pressing **Escape**, which *cancels* the dialog and leaves the editor **open and still dirty**, then gave up (`break`). So the dirty editor — and its modal, once re-triggered — survived into later tests.

### The fix

`closeAllEditors()` now dismisses the prompt with **"Don't Save"** (discarding the changes) so the editor actually closes and no modal is left behind. If the dialog can't be handled it falls back to the previous Escape behavior — no regression. This cleanup path runs in the before/after hooks of ~19 test suites.

Note this is **defense-in-depth for a pre-existing weakness**, not a revert of a specific regression: the underlying flakiness (heterogeneous `click intercepted` / stale-element / `isDisplayed` timeouts on the min-version runners) predates the recent merges, but this dirty-editor cascade is a concrete, fixable amplifier.

## Testing

- New UI regression test (`editor/editorViewCleanup.test.ts`), written TDD-first: it opens a dirty editor and calls `closeAllEditors`. Against the old code it **times out at 60s** (the editor never closes); with the fix it **passes in ~5s** with zero open editors and zero `.monaco-dialog-modal-block` overlays remaining.
- Local (macOS / VS Code 1.131.0): editor group 106/106, bottomBar 25/25. The `dialog` suite (which intentionally raises and manages this modal via `closeEditor` + `ModalDialog`, not `closeAllEditors`) is unaffected by the change and is macOS-skipped locally; it runs on Windows/Linux CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
