### PR TITLE
feat(extester): accept JSONC settings files, validate their shape and log overridden defaults

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1856,6 +1856,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -2790,6 +2791,7 @@
       "integrity": "sha512-fHq2VC1kpyYfvEcbiMjOpySY4WS7voEp89yAThrHRX5sm9j2lzYppCb2umFMEed4fWcyeLjHxrz0mpjNBaBxMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.68.0",
         "@typescript-eslint/types": "8.68.0",
@@ -3614,6 +3616,7 @@
       "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5600,6 +5603,7 @@
       "integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -5659,6 +5663,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -9069,6 +9074,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.4.5",
         "@emnapi/runtime": "1.4.5",
@@ -10227,6 +10233,7 @@
       "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -11006,6 +11013,7 @@
         }
       ],
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@bazel/runfiles": "^6.5.0",
         "jszip": "^3.10.1",
@@ -11997,6 +12005,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12707,6 +12716,7 @@
         "got": "^15.1.0",
         "hpagent": "^1.2.0",
         "js-yaml": "^5.4.1",
+        "jsonc-parser": "^3.2.0",
         "sanitize-filename": "^1.6.4",
         "selenium-webdriver": "^4.48.0",
         "tar": "^7.5.22"

--- a/packages/extester/package.json
+++ b/packages/extester/package.json
@@ -74,6 +74,7 @@
     "got": "^15.1.0",
     "hpagent": "^1.2.0",
     "js-yaml": "^5.4.1",
+    "jsonc-parser": "^3.2.0",
     "sanitize-filename": "^1.6.4",
     "selenium-webdriver": "^4.48.0",
     "tar": "^7.5.22"

--- a/packages/extester/src/browser.ts
+++ b/packages/extester/src/browser.ts
@@ -22,7 +22,7 @@ import { satisfies } from 'compare-versions';
 import { WebDriver, Builder, initPageObjects, logging, By, Browser, EditorView, Workbench } from '@redhat-developer/page-objects';
 import { Options, ServiceBuilder } from 'selenium-webdriver/chrome';
 import { getLocatorsPath } from '@redhat-developer/locators';
-import { CodeUtil, CustomPageObjectsOptions, ReleaseQuality } from './util/codeUtil';
+import { CodeUtil, CustomPageObjectsOptions, ReleaseQuality, overriddenDefaultKeys } from './util/codeUtil';
 import { DEFAULT_STORAGE_FOLDER } from './extester';
 import { DriverUtil } from './util/driverUtil';
 
@@ -137,11 +137,24 @@ export class VSBrowser {
 		};
 		if (Object.keys(this.customSettings).length > 0) {
 			console.log('Detected user defined code settings');
+			// Several defaults are load-bearing for the framework itself (e.g. custom
+			// title bar and dialogs for the page objects, reduced motion for stable
+			// waits, disabled updates) — make it visible when custom settings change them.
+			const custom = this.customSettings as Record<string, unknown>;
+			const overridden = overriddenDefaultKeys(defaultSettings, custom);
+			if (overridden.length > 0) {
+				const diff = overridden.map(
+					(key) => `${key} (${JSON.stringify(defaultSettings[key as keyof typeof defaultSettings])} -> ${JSON.stringify(custom[key])})`,
+				);
+				console.log('\x1b[33m%s\x1b[0m', `WARNING: Custom settings override framework defaults: ${diff.join(', ')}`);
+			}
 			defaultSettings = { ...defaultSettings, ...this.customSettings };
 		}
 
 		fs.mkdirpSync(path.join(userSettings, 'globalStorage'));
-		fs.writeJSONSync(path.join(userSettings, 'settings.json'), defaultSettings);
+		// tab indentation matches how VS Code itself writes settings.json and keeps
+		// the file readable when debugging which settings were actually applied
+		fs.writeJSONSync(path.join(userSettings, 'settings.json'), defaultSettings, { spaces: '\t' });
 		console.log(`Writing code settings to ${path.join(userSettings, 'settings.json')}`);
 
 		if (this.locale) {

--- a/packages/extester/src/test/codeUtil.test.ts
+++ b/packages/extester/src/test/codeUtil.test.ts
@@ -21,7 +21,7 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as vsce from '@vscode/vsce';
 import type { IPackageOptions } from '@vscode/vsce';
-import { CodeUtil } from '../util/codeUtil';
+import { CodeUtil, overriddenDefaultKeys } from '../util/codeUtil';
 import { ReleaseQuality } from '../util/codeUtil';
 import { Download } from '../util/download';
 
@@ -79,6 +79,92 @@ describe('CodeUtil.packageExtension', () => {
 		const util = makeCodeUtil();
 		await util.packageExtension(frozen);
 		assert.deepStrictEqual(capturedOptions, { useYarn: true });
+	});
+});
+
+describe('CodeUtil.parseSettings', () => {
+	let dir: string;
+
+	beforeEach(async () => {
+		dir = await fs.mkdtemp(path.join(os.tmpdir(), 'extest-settings-'));
+	});
+
+	afterEach(async () => {
+		await fs.remove(dir);
+	});
+
+	type WithParseSettings = { parseSettings(settingsPath: string): object };
+
+	function parseContent(content: string): object {
+		const file = path.join(dir, 'settings.json');
+		fs.writeFileSync(file, content);
+		const util = new CodeUtil(dir, ReleaseQuality.Stable) as unknown as WithParseSettings;
+		return util.parseSettings(file);
+	}
+
+	it('returns an empty object when no path is given', () => {
+		const util = new CodeUtil(dir, ReleaseQuality.Stable) as unknown as WithParseSettings;
+		assert.deepStrictEqual(util.parseSettings(''), {});
+	});
+
+	it('parses a plain JSON object', () => {
+		assert.deepStrictEqual(parseContent('{"update.mode": "none"}'), { 'update.mode': 'none' });
+	});
+
+	it('accepts JSONC comments and trailing commas like VS Code settings.json does', () => {
+		const jsonc = '{\n\t// comment line\n\t"workbench.statusBar.visible": false,\n\t/* block comment */\n\t"window.zoomLevel": 1,\n}';
+		assert.deepStrictEqual(parseContent(jsonc), { 'workbench.statusBar.visible': false, 'window.zoomLevel': 1 });
+	});
+
+	it('returns an empty object for an empty settings file', () => {
+		assert.deepStrictEqual(parseContent('  \n\t\n'), {});
+	});
+
+	it('rejects a root-level array with an error naming the type', () => {
+		assert.throws(() => parseContent('["not", "settings"]'), /must contain a JSON object at the root.*array/);
+	});
+
+	it('rejects a root-level string with an error naming the type', () => {
+		assert.throws(() => parseContent('"just a string"'), /must contain a JSON object at the root.*string/);
+	});
+
+	it('rejects a root-level null with an error naming the type', () => {
+		assert.throws(() => parseContent('null'), /must contain a JSON object at the root.*null/);
+	});
+
+	it('rejects malformed JSON with an error naming the file', () => {
+		assert.throws(
+			() => parseContent('{"a": }'),
+			(err: Error) => err.message.includes(path.join(dir, 'settings.json')),
+		);
+	});
+
+	it('throws a readable error for an unreadable file', () => {
+		const util = new CodeUtil(dir, ReleaseQuality.Stable) as unknown as WithParseSettings;
+		assert.throws(() => util.parseSettings(path.join(dir, 'missing.json')), /Unable to read settings/);
+	});
+});
+
+describe('overriddenDefaultKeys', () => {
+	const defaults = { 'update.mode': 'none', 'window.titleBarStyle': 'custom', 'workbench.reduceMotion': 'on' };
+
+	it('lists custom keys that change a default value', () => {
+		const custom = { 'window.titleBarStyle': 'native', 'update.mode': 'default' };
+		assert.deepStrictEqual(overriddenDefaultKeys(defaults, custom), ['window.titleBarStyle', 'update.mode']);
+	});
+
+	it('ignores custom keys that are not framework defaults', () => {
+		const custom = { 'editor.fontSize': 20, 'files.autoSave': 'off' };
+		assert.deepStrictEqual(overriddenDefaultKeys(defaults, custom), []);
+	});
+
+	it('ignores custom keys set to the same value as the default', () => {
+		const custom = { 'update.mode': 'none', 'workbench.reduceMotion': 'off' };
+		assert.deepStrictEqual(overriddenDefaultKeys(defaults, custom), ['workbench.reduceMotion']);
+	});
+
+	it('returns an empty list for empty custom settings', () => {
+		assert.deepStrictEqual(overriddenDefaultKeys(defaults, {}), []);
 	});
 });
 

--- a/packages/extester/src/util/codeUtil.ts
+++ b/packages/extester/src/util/codeUtil.ts
@@ -18,6 +18,7 @@
 import * as childProcess from 'child_process';
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import { parse as parseJsonc, printParseErrorCode, type ParseError } from 'jsonc-parser';
 import * as vsce from '@vscode/vsce';
 import type { IPackageOptions } from '@vscode/vsce';
 import { VSRunner } from '../suite/runner';
@@ -59,6 +60,15 @@ export interface RunOptions {
 	customPageObjects?: CustomPageObjectsOptions;
 	/** Display language locale for VS Code (e.g. 'ru', 'zh-cn', 'fr'). Requires the matching language pack extension to be installed. */
 	locale?: string;
+}
+
+/**
+ * List the keys in `custom` that change a value in `defaults`.
+ * Used to warn when user-supplied settings override the framework's
+ * injected defaults, several of which the page objects depend on.
+ */
+export function overriddenDefaultKeys(defaults: Record<string, unknown>, custom: Record<string, unknown>): string[] {
+	return Object.keys(custom).filter((key) => key in defaults && defaults[key] !== custom[key]);
 }
 
 /** defaults for the [[RunOptions]] */
@@ -692,8 +702,10 @@ export class CodeUtil {
 	}
 
 	/**
-	 * Parse JSON from a file
-	 * @param path path to json file
+	 * Parse a VS Code settings file. Accepts JSONC (comments and trailing
+	 * commas), matching what VS Code itself allows in settings.json, so users
+	 * can pass a copy of their own settings file directly.
+	 * @param path path to the settings file
 	 */
 	private parseSettings(path: string): object {
 		if (!path) {
@@ -705,10 +717,21 @@ export class CodeUtil {
 		} catch (err) {
 			throw new Error(`Unable to read settings from ${path}:\n ${err}`);
 		}
-		try {
-			return JSON.parse(text);
-		} catch (err) {
-			throw new Error(`Error parsing the settings file from ${path}:\n ${err}`);
+		// VS Code treats an empty settings.json as valid
+		if (text.trim() === '') {
+			return {};
 		}
+		const errors: ParseError[] = [];
+		const parsed: unknown = parseJsonc(text, errors, { allowTrailingComma: true });
+		if (errors.length > 0) {
+			const { error, offset } = errors[0];
+			const line = text.slice(0, offset).split('\n').length;
+			throw new Error(`Error parsing the settings file from ${path}:\n ${printParseErrorCode(error)} at line ${line} (offset ${offset})`);
+		}
+		if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+			const rootType = parsed === null ? 'null' : Array.isArray(parsed) ? 'array' : typeof parsed;
+			throw new Error(`Settings file ${path} must contain a JSON object at the root, got ${rootType}`);
+		}
+		return parsed;
 	}
 }


### PR DESCRIPTION
## What

Three fixes to how `--code_settings` custom settings are parsed and applied (P1 of a settings-propagation audit):

- **JSONC support** — `parseSettings` now uses `jsonc-parser` (new direct dependency, same parser family VS Code uses), so a copy of a real VS Code `settings.json` with comments and trailing commas is accepted instead of failing on strict `JSON.parse`. An empty file resolves to `{}`, matching VS Code's own tolerance, and parse errors report the error code plus line number.
- **Root-shape validation** — a settings file whose root is an array, string, or `null` now fails fast with `Settings file <path> must contain a JSON object at the root, got <type>`. Previously an array/string root silently wrote index-keyed garbage (`"0": "x"`, …) into the injected settings.json, and a `null` root crashed much later inside mocha's `beforeAll` with an unrelated `Cannot convert undefined or null to object`.
- **Observability** — a new `overriddenDefaultKeys()` helper reports which framework defaults the custom file changes; `VSBrowser.start()` logs a warning with the old → new values (several defaults are load-bearing for the page objects: custom title bar/dialog styles, reduced motion, disabled updates). The merged settings.json is now written tab-indented, as VS Code itself writes it, so it is readable when debugging which settings were applied.

## Testing

- 13 new unit tests written test-first (TDD): 9 for `parseSettings` (JSONC, empty file, plain JSON, array/string/null roots, malformed JSON, unreadable file, no path) and 4 for `overriddenDefaultKeys`. Full `test:unit` suite: 84 passing.
- Verified end-to-end on VS Code 1.135.0 via the real CLI: a JSONC settings file with comments and a trailing comma launches cleanly, the log prints `WARNING: Custom settings override framework defaults: window.commandCenter (false -> true)`, settings.json lands tab-indented, and the custom setting is honored at launch and across an `openResources` window reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)