### PR TITLE
feat(extester): warn on shadowed settings, apply custom settings in setup phase, preflight storage path length

### DIFF
--- a/docs/Test-Setup.md
+++ b/docs/Test-Setup.md
@@ -115,6 +115,7 @@ Options:
   -e, --extensions_dir <extensions_directory>  # VS Code will use this directory for managing extensions
   -c, --code_version <version>                 # Version of VS Code to download
   -t, --type <type>                            # Type of VS Code release (stable/insider)
+  -o, --code_settings <settings.json>          # Path to custom settings for VS Code json file, applied before setup-phase CLI steps
   --package_options <json>                     # JSON string of vsce IPackageOptions (e.g. '{"useYarn":true,"followSymlinks":true}')
   -i, --install_dependencies                   # Automatically install extensions your extension depends on (default: false)
   -n, --no_cache                               # Disable caching of VS Code and ChromeDriver downloads (default: false)
@@ -176,6 +177,38 @@ Options:
   --config <path>                              # Path to extester.config.json configuration file
   -h, --help                                   # display help for command
 ```
+
+## How custom settings propagate
+
+The file passed via `-o`/`--code_settings` (or `run.settings` in the config file) is parsed as JSONC — comments and trailing commas are accepted, exactly as VS Code itself accepts them in `settings.json` — so you can pass a copy of your own settings file directly. The root must be a JSON object.
+
+Before launch, ExTester merges your settings **on top of** its own framework defaults and writes the result to `<storage>/settings/User/settings.json` (user scope). Your values win on every key. These are the injected defaults:
+
+| Setting                                          | Value        | Why the framework sets it                                            |
+| ------------------------------------------------ | ------------ | -------------------------------------------------------------------- |
+| `update.mode` / `update.showReleaseNotes`        | `none` / off | A mid-run self-update corrupts the instance under test               |
+| `extensions.autoUpdate` / `autoCheckUpdates`     | off          | Same — extension state must not change mid-run                       |
+| `window.titleBarStyle` / `window.menuStyle`      | `custom`     | TitleBar/menu page objects only work with the custom title bar       |
+| `window.dialogStyle`                             | `custom`     | ModalDialog page objects (incl. the dirty-editor discard) need it    |
+| `workbench.reduceMotion`                         | `on`         | Disables UI animations that make element waits environment-dependent |
+| `files.simpleDialog.enable`                      | `true`       | Open/save dialog page objects need the simple (in-window) dialog     |
+| `security.workspace.trust.enabled`               | `false`      | Trust prompts would block the first window                           |
+| `workbench.editor.enablePreview`                 | `false`      | Editor tests assume real tabs, not preview tabs                      |
+| `workbench.startupEditor` + welcome/walkthroughs | none/off     | A deterministic empty workbench at startup                           |
+| `window.commandCenter`                           | `false`      | Keeps the title bar layout the page objects expect                   |
+
+Overriding one of these is allowed but prints a warning with the old → new values, since several of them are load-bearing for the page objects.
+
+Two things outrank your settings file:
+
+1. **Always-on launch flags.** ExTester starts VS Code with `--disable-updates`, `--disable-workspace-trust`, `--disable-telemetry`, `--disable-experiments` and `--skip-welcome`, and CLI flags win over `settings.json`. A setting that tries to re-enable one of these (e.g. `"security.workspace.trust.enabled": true`) has no effect; ExTester prints a warning when it detects this.
+2. **Workspace settings.** Your file is written at _user_ scope. Any folder or workspace you open — via `-r`/`--open_resource` or `VSBrowser.openResources()` — that carries its own `.vscode/settings.json` shadows your value for the keys it defines, per VS Code's normal precedence. This is the classic "my setting worked until the window reloaded" trap: opening a folder reloads the window, and the folder's workspace settings take over — while the user-scope file on disk still shows your value. ExTester prints a warning naming the shadowed keys when this happens.
+
+Custom settings are applied at launch. To change a setting mid-test, use the `SettingsEditor` page object.
+
+`setup-tests` also accepts `-o`/`--code_settings` (config: `setup.settings`): the parsed settings are written before setup-phase CLI steps run, so settings such as `http.proxy` apply to marketplace extension installs. `setup-and-run` reuses the run-phase settings for its setup phase automatically.
+
+One practical note on the storage folder: the settings dir doubles as VS Code's `--user-data-dir`, which hosts an IPC socket whose path must fit the OS socket limit (~104 bytes on macOS, ~108 on Linux). ExTester fails fast with a clear error if your storage path is too deep — use a shorter `-s`/`--storage` or `TEST_RESOURCES` if you hit it.
 
 ## Using a Config File
 
@@ -266,15 +299,16 @@ All fields are optional. Paths are resolved relative to the config file's locati
 
 Controls VS Code + ChromeDriver download and extension installation. Used by `get-vscode`, `get-chromedriver`, `install-vsix`, `setup-tests`, and `setup-and-run`.
 
-| Field                 | Type                      | Default                                       | CLI equivalent                  | Description                                             |
-| --------------------- | ------------------------- | --------------------------------------------- | ------------------------------- | ------------------------------------------------------- |
-| `vscodeVersion`       | string                    | `"latest"`                                    | `-c` / `--code_version`         | VS Code version: `latest`, `min`, `max`, or `1.X.Y`     |
-| `type`                | `"stable"` \| `"insider"` | `"stable"`                                    | `-t` / `--type`                 | VS Code release stream                                  |
-| `storage`             | string                    | `$TEST_RESOURCES` or `$TMPDIR/test-resources` | `-s` / `--storage`              | Folder for all downloaded test resources                |
-| `extensionsDir`       | string                    | —                                             | `-e` / `--extensions_dir`       | VS Code extensions directory override                   |
-| `packageOptions`      | object                    | —                                             | `--package_options`             | vsce `IPackageOptions` forwarded to `vsce.createVSIX()` |
-| `installDependencies` | boolean                   | `false`                                       | `-i` / `--install_dependencies` | Install marketplace dependencies automatically          |
-| `noCache`             | boolean                   | `false`                                       | `-n` / `--no_cache`             | Skip cached downloads                                   |
+| Field                 | Type                      | Default                                       | CLI equivalent                  | Description                                                                                                |
+| --------------------- | ------------------------- | --------------------------------------------- | ------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `vscodeVersion`       | string                    | `"latest"`                                    | `-c` / `--code_version`         | VS Code version: `latest`, `min`, `max`, or `1.X.Y`                                                        |
+| `type`                | `"stable"` \| `"insider"` | `"stable"`                                    | `-t` / `--type`                 | VS Code release stream                                                                                     |
+| `storage`             | string                    | `$TEST_RESOURCES` or `$TMPDIR/test-resources` | `-s` / `--storage`              | Folder for all downloaded test resources                                                                   |
+| `extensionsDir`       | string                    | —                                             | `-e` / `--extensions_dir`       | VS Code extensions directory override                                                                      |
+| `packageOptions`      | object                    | —                                             | `--package_options`             | vsce `IPackageOptions` forwarded to `vsce.createVSIX()`                                                    |
+| `settings`            | string                    | —                                             | `-o` / `--code_settings`        | Custom `settings.json` applied before setup-phase CLI steps (e.g. proxy settings for marketplace installs) |
+| `installDependencies` | boolean                   | `false`                                       | `-i` / `--install_dependencies` | Install marketplace dependencies automatically                                                             |
+| `noCache`             | boolean                   | `false`                                       | `-n` / `--no_cache`             | Skip cached downloads                                                                                      |
 
 #### `run` section
 
@@ -287,7 +321,7 @@ Controls test execution inside VS Code. Used by `run-tests` and `setup-and-run`.
 | `type`              | `"stable"` \| `"insider"` | `"stable"`                                    | `-t` / `--type`                | VS Code release stream                                                                                                                                                                                         |
 | `storage`           | string                    | `$TEST_RESOURCES` or `$TMPDIR/test-resources` | `-s` / `--storage`             | Folder for all downloaded test resources                                                                                                                                                                       |
 | `extensionsDir`     | string                    | —                                             | `-e` / `--extensions_dir`      | VS Code extensions directory override                                                                                                                                                                          |
-| `settings`          | string                    | —                                             | `-o` / `--code_settings`       | Path to a custom VS Code `settings.json`                                                                                                                                                                       |
+| `settings`          | string                    | —                                             | `-o` / `--code_settings`       | Path to a custom VS Code `settings.json`. See [How custom settings propagate](#how-custom-settings-propagate)                                                                                                  |
 | `cleanup`           | boolean                   | `false`                                       | `-u` / `--uninstall_extension` | Uninstall the extension after the test run                                                                                                                                                                     |
 | `mochaConfig`       | string                    | —                                             | `-m` / `--mocha_config`        | Path to a Mocha configuration file                                                                                                                                                                             |
 | `logLevel`          | string                    | `"Info"`                                      | `-l` / `--log_level`           | Webdriver and ChromeDriver log level: `Debug`, `Info`, `Warning`, `Severe`, `OFF`, `ALL` (`ALL` records the full CDP wire traffic in `chromedriver.log` and can grow it by hundreds of MB over a long session) |

--- a/packages/extester/resources/extester.schema.json
+++ b/packages/extester/resources/extester.schema.json
@@ -217,6 +217,11 @@
           },
           "additionalProperties": true
         },
+        "settings": {
+          "type": "string",
+          "description": "Path to a custom VS Code settings.json file to apply before setup-phase CLI steps (e.g. proxy settings for marketplace installs).",
+          "examples": ["./vscode-settings.json"]
+        },
         "installDependencies": {
           "type": "boolean",
           "description": "Automatically install extensions your extension depends on from the marketplace.",

--- a/packages/extester/src/browser.ts
+++ b/packages/extester/src/browser.ts
@@ -22,7 +22,15 @@ import { satisfies } from 'compare-versions';
 import { WebDriver, Builder, initPageObjects, logging, By, Browser, EditorView, Workbench } from '@redhat-developer/page-objects';
 import { Options, ServiceBuilder } from 'selenium-webdriver/chrome';
 import { getLocatorsPath } from '@redhat-developer/locators';
-import { CodeUtil, CustomPageObjectsOptions, ReleaseQuality, overriddenDefaultKeys } from './util/codeUtil';
+import {
+	CodeUtil,
+	CustomPageObjectsOptions,
+	ReleaseQuality,
+	findShadowedSettings,
+	flagConflictWarnings,
+	overriddenDefaultKeys,
+	validateUserDataDirLength,
+} from './util/codeUtil';
 import { DEFAULT_STORAGE_FOLDER } from './extester';
 import { DriverUtil } from './util/driverUtil';
 
@@ -76,6 +84,14 @@ export class VSBrowser {
 		const settingsDir = path.join(this.storagePath, 'settings');
 		const userSettings = path.join(settingsDir, 'User');
 		const languagePacksPath = path.join(settingsDir, 'languagepacks.json');
+
+		// A too-long user data dir path makes VS Code die instantly on its IPC
+		// socket bind, surfaced by ChromeDriver only as "Chrome instance exited" —
+		// fail here with an actionable message instead.
+		const pathLengthError = validateUserDataDirLength(settingsDir);
+		if (pathLengthError) {
+			throw new Error(pathLengthError);
+		}
 
 		// Preserve languagepacks.json across the settings wipe.
 		// It is written by the VS Code CLI install step (installExt) with --user-data-dir
@@ -148,6 +164,11 @@ export class VSBrowser {
 				);
 				console.log('\x1b[33m%s\x1b[0m', `WARNING: Custom settings override framework defaults: ${diff.join(', ')}`);
 			}
+			// CLI flags beat settings.json in VS Code, so settings trying to
+			// re-enable what an always-on launch flag disables are silently dead.
+			for (const warning of flagConflictWarnings(custom)) {
+				console.log('\x1b[33m%s\x1b[0m', `WARNING: ${warning}`);
+			}
 			defaultSettings = { ...defaultSettings, ...this.customSettings };
 		}
 
@@ -206,6 +227,7 @@ export class VSBrowser {
 		// second-instance CLI call: when such a call lands while VS Code is still
 		// starting up, VS Code >= 1.123.0 corrupts webview resource streaming for
 		// the whole window (microsoft/vscode#330243, #2454).
+		this.warnShadowedSettings(resources);
 		for (const resource of resources) {
 			args.push(VSBrowser.resourceToLaunchArg(resource));
 		}
@@ -277,6 +299,30 @@ export class VSBrowser {
 		// handler would abort the whole suite on any stray async error.
 		process.on('SIGINT', () => void emergencyShutdown('SIGINT', 130));
 		process.on('SIGTERM', () => void emergencyShutdown('SIGTERM', 143));
+	}
+
+	/**
+	 * Warn when a folder being opened carries workspace settings that shadow
+	 * the user-supplied custom settings: workspace scope wins over user scope,
+	 * so those custom settings silently stop applying once the folder is open
+	 * — while the injected settings.json still shows the custom value.
+	 */
+	private warnShadowedSettings(resources: string[]): void {
+		const custom = this.customSettings as Record<string, unknown>;
+		if (Object.keys(custom).length === 0) {
+			return;
+		}
+		for (const resource of resources) {
+			const resolved = path.resolve(resource);
+			const shadowed = findShadowedSettings(resolved, custom);
+			if (shadowed.length > 0) {
+				const diff = shadowed.map((entry) => `${entry.key} (${JSON.stringify(custom[entry.key])} -> ${JSON.stringify(entry.workspaceValue)})`);
+				console.log(
+					'\x1b[33m%s\x1b[0m',
+					`WARNING: Workspace settings in ${path.join(resolved, '.vscode', 'settings.json')} shadow custom settings: ${diff.join(', ')}`,
+				);
+			}
+		}
 	}
 
 	/**
@@ -457,6 +503,7 @@ export class VSBrowser {
 			return;
 		}
 
+		this.warnShadowedSettings(paths);
 		const code = new CodeUtil(this.storagePath, this.releaseType, this.extensionsFolder);
 		code.open(...paths);
 		await this.waitForWorkbench(undefined, waitForFn);

--- a/packages/extester/src/cli.ts
+++ b/packages/extester/src/cli.ts
@@ -146,6 +146,7 @@ program
 	.option('-e, --extensions_dir <extensions_directory>', 'VS Code will use this directory for managing extensions')
 	.option('-c, --code_version <version>', 'Version of VS Code to download, use `min`/`max` to download the oldest/latest VS Code supported by ExTester')
 	.option('-t, --type <type>', 'Type of VS Code release (stable/insider)')
+	.option('-o, --code_settings <settings.json>', 'Path to custom settings for VS Code json file, applied before setup-phase CLI steps')
 	.option('--package_options <json>', 'JSON string of vsce IPackageOptions passed to vsce.createVSIX() (e.g. \'{"useYarn":true,"followSymlinks":true}\')')
 	.option('-i, --install_dependencies', 'Automatically install extensions your extension depends on', false)
 	.option('-n, --no_cache', 'Skip using cached version and download fresh copy without caching it', false)
@@ -159,6 +160,7 @@ program
 			await extest.setupRequirements({
 				vscodeVersion: cmd.code_version ?? setup.vscodeVersion,
 				packageOptions,
+				settings: cmd.code_settings ?? setup.settings,
 				installDependencies: cmd.install_dependencies || setup.installDependencies,
 				noCache: cmd.no_cache || setup.noCache,
 			});
@@ -253,6 +255,7 @@ program
 				cmd.code_version ?? setup.vscodeVersion ?? run.vscodeVersion,
 				{
 					packageOptions,
+					settings: cmd.code_settings ?? setup.settings ?? run.settings,
 					installDependencies: cmd.install_dependencies || setup.installDependencies,
 					noCache: cmd.no_cache || setup.noCache,
 				},

--- a/packages/extester/src/config.ts
+++ b/packages/extester/src/config.ts
@@ -35,6 +35,8 @@ export interface ExTesterSetupConfig {
 	extensionsDir?: string;
 	/** vsce packaging options forwarded directly to `vsce.createVSIX()`. */
 	packageOptions?: IPackageOptions;
+	/** Path to a custom VS Code `settings.json` file to apply before setup-phase CLI steps (e.g. proxy settings for marketplace installs). */
+	settings?: string;
 	/** Automatically install extensions your extension depends on from the marketplace. Defaults to `false`. */
 	installDependencies?: boolean;
 	/** Skip using a cached download and fetch a fresh copy. Defaults to `false`. */
@@ -103,7 +105,7 @@ export interface ExTesterConfig {
 }
 
 /** Path-valued keys in ExTesterSetupConfig that must be resolved relative to the config file. */
-const SETUP_PATH_KEYS: (keyof ExTesterSetupConfig)[] = ['storage', 'extensionsDir'];
+const SETUP_PATH_KEYS: (keyof ExTesterSetupConfig)[] = ['storage', 'extensionsDir', 'settings'];
 
 /** Path-valued keys in ExTesterRunConfig that must be resolved relative to the config file. */
 const RUN_PATH_KEYS: (keyof ExTesterRunConfig)[] = ['storage', 'extensionsDir', 'settings', 'mochaConfig', 'customPageObjects'];

--- a/packages/extester/src/extester.ts
+++ b/packages/extester/src/extester.ts
@@ -38,6 +38,8 @@ export interface SetupOptions {
 	vscodeVersion?: string;
 	/** vsce packaging options passed directly to vsce.createVSIX() — use e.g. `{ useYarn: true, followSymlinks: true }` */
 	packageOptions?: IPackageOptions;
+	/** path to a custom settings json file to apply before setup-phase CLI steps (e.g. proxy settings for marketplace installs) */
+	settings?: string;
 	/** install the extension's dependencies from the marketplace. Defaults to `false`. */
 	installDependencies?: boolean;
 	/** skip using cached version and download fresh copy */
@@ -183,7 +185,12 @@ export class ExTester {
 	 * @param noCache whether to skip using cached version
 	 */
 	async setupRequirements(options: SetupOptions = DEFAULT_SETUP_OPTIONS, offline = false, cleanup = false): Promise<void> {
-		const { packageOptions, vscodeVersion, installDependencies, noCache } = options;
+		const { packageOptions, vscodeVersion, installDependencies, noCache, settings } = options;
+
+		// Custom settings are written before any CLI-driven step so that e.g.
+		// marketplace installs honor proxy settings from the settings file.
+		// VSBrowser.start() rewrites the file merged with framework defaults.
+		this.code.writeUserSettings(settings ?? '');
 
 		const vscodeParsedVersion = loadCodeVersion(vscodeVersion);
 		if (!offline) {
@@ -226,7 +233,11 @@ export class ExTester {
 		setupOptions: Omit<SetupOptions, 'vscodeVersion'> = DEFAULT_SETUP_OPTIONS,
 		runOptions: Omit<RunOptions, 'vscodeVersion'> = DEFAULT_RUN_OPTIONS,
 	): Promise<number> {
-		await this.setupRequirements({ ...setupOptions, vscodeVersion }, runOptions.offline, runOptions.cleanup);
+		await this.setupRequirements(
+			{ ...setupOptions, vscodeVersion, settings: setupOptions.settings ?? runOptions.settings },
+			runOptions.offline,
+			runOptions.cleanup,
+		);
 		return await this.runTests(testFilesPattern, {
 			...runOptions,
 			vscodeVersion,

--- a/packages/extester/src/test/codeUtil.test.ts
+++ b/packages/extester/src/test/codeUtil.test.ts
@@ -21,7 +21,7 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as vsce from '@vscode/vsce';
 import type { IPackageOptions } from '@vscode/vsce';
-import { CodeUtil, overriddenDefaultKeys } from '../util/codeUtil';
+import { CodeUtil, overriddenDefaultKeys, validateUserDataDirLength, flagConflictWarnings, findShadowedSettings } from '../util/codeUtil';
 import { ReleaseQuality } from '../util/codeUtil';
 import { Download } from '../util/download';
 
@@ -165,6 +165,168 @@ describe('overriddenDefaultKeys', () => {
 
 	it('returns an empty list for empty custom settings', () => {
 		assert.deepStrictEqual(overriddenDefaultKeys(defaults, {}), []);
+	});
+});
+
+describe('CodeUtil.writeUserSettings', () => {
+	let dir: string;
+
+	beforeEach(async () => {
+		dir = await fs.mkdtemp(path.join(os.tmpdir(), 'extest-setup-settings-'));
+	});
+
+	afterEach(async () => {
+		await fs.remove(dir);
+	});
+
+	it('writes parsed JSONC settings into the storage settings dir, tab-indented', () => {
+		const settingsFile = path.join(dir, 'custom.json');
+		fs.writeFileSync(settingsFile, '{\n// proxy for marketplace installs\n"http.proxy": "http://proxy:3128",\n}');
+		const util = new CodeUtil(dir, ReleaseQuality.Stable);
+		util.writeUserSettings(settingsFile);
+		const written = fs.readFileSync(path.join(dir, 'settings', 'User', 'settings.json'), 'utf-8');
+		assert.ok(written.includes('\t"http.proxy": "http://proxy:3128"'), 'settings should be written tab-indented');
+	});
+
+	it('does nothing when no settings path is given', () => {
+		const util = new CodeUtil(dir, ReleaseQuality.Stable);
+		util.writeUserSettings('');
+		assert.strictEqual(fs.existsSync(path.join(dir, 'settings', 'User', 'settings.json')), false);
+	});
+
+	it('propagates validation errors from the settings file', () => {
+		const settingsFile = path.join(dir, 'bad.json');
+		fs.writeFileSync(settingsFile, '["not settings"]');
+		const util = new CodeUtil(dir, ReleaseQuality.Stable);
+		assert.throws(() => util.writeUserSettings(settingsFile), /must contain a JSON object at the root/);
+	});
+});
+
+describe('findShadowedSettings', () => {
+	let dir: string;
+
+	beforeEach(async () => {
+		dir = await fs.mkdtemp(path.join(os.tmpdir(), 'extest-shadow-'));
+	});
+
+	afterEach(async () => {
+		await fs.remove(dir);
+	});
+
+	function writeWorkspaceSettings(content: string): void {
+		fs.outputFileSync(path.join(dir, '.vscode', 'settings.json'), content);
+	}
+
+	it('reports a custom key that the workspace file sets to a different value', () => {
+		writeWorkspaceSettings('{"workbench.statusBar.visible": true}');
+		const shadowed = findShadowedSettings(dir, { 'workbench.statusBar.visible': false });
+		assert.deepStrictEqual(shadowed, [{ key: 'workbench.statusBar.visible', workspaceValue: true }]);
+	});
+
+	it('ignores keys the workspace file sets to the same value', () => {
+		writeWorkspaceSettings('{"workbench.statusBar.visible": false}');
+		assert.deepStrictEqual(findShadowedSettings(dir, { 'workbench.statusBar.visible': false }), []);
+	});
+
+	it('ignores workspace keys that are not in the custom settings', () => {
+		writeWorkspaceSettings('{"window.zoomLevel": -1.5}');
+		assert.deepStrictEqual(findShadowedSettings(dir, { 'workbench.statusBar.visible': false }), []);
+	});
+
+	it('returns nothing for a folder without workspace settings', () => {
+		assert.deepStrictEqual(findShadowedSettings(dir, { 'workbench.statusBar.visible': false }), []);
+	});
+
+	it('returns nothing for a file path', () => {
+		const file = path.join(dir, 'some.txt');
+		fs.writeFileSync(file, 'hello');
+		assert.deepStrictEqual(findShadowedSettings(file, { 'workbench.statusBar.visible': false }), []);
+	});
+
+	it('reads JSONC workspace files with comments and trailing commas', () => {
+		writeWorkspaceSettings('{\n\t// zoom for CI\n\t"window.zoomLevel": -1.5,\n}');
+		const shadowed = findShadowedSettings(dir, { 'window.zoomLevel': 0 });
+		assert.deepStrictEqual(shadowed, [{ key: 'window.zoomLevel', workspaceValue: -1.5 }]);
+	});
+
+	it('never throws on a malformed workspace file', () => {
+		writeWorkspaceSettings('{{{ not json');
+		assert.deepStrictEqual(findShadowedSettings(dir, { 'window.zoomLevel': 0 }), []);
+	});
+});
+
+describe('flagConflictWarnings', () => {
+	it('warns when workspace trust is enabled against --disable-workspace-trust', () => {
+		const warnings = flagConflictWarnings({ 'security.workspace.trust.enabled': true });
+		assert.strictEqual(warnings.length, 1);
+		assert.ok(warnings[0].includes('security.workspace.trust.enabled'));
+		assert.ok(warnings[0].includes('--disable-workspace-trust'));
+	});
+
+	it('warns when update.mode re-enables updates against --disable-updates', () => {
+		const warnings = flagConflictWarnings({ 'update.mode': 'default' });
+		assert.strictEqual(warnings.length, 1);
+		assert.ok(warnings[0].includes('--disable-updates'));
+	});
+
+	it('stays quiet when update.mode matches the disabled state', () => {
+		assert.deepStrictEqual(flagConflictWarnings({ 'update.mode': 'none' }), []);
+	});
+
+	it('warns when telemetry is turned on against --disable-telemetry', () => {
+		const warnings = flagConflictWarnings({ 'telemetry.telemetryLevel': 'all' });
+		assert.strictEqual(warnings.length, 1);
+		assert.ok(warnings[0].includes('--disable-telemetry'));
+	});
+
+	it('stays quiet when telemetry is off', () => {
+		assert.deepStrictEqual(flagConflictWarnings({ 'telemetry.telemetryLevel': 'off' }), []);
+	});
+
+	it('warns when experiments are enabled against --disable-experiments', () => {
+		const warnings = flagConflictWarnings({ 'workbench.enableExperiments': true });
+		assert.strictEqual(warnings.length, 1);
+		assert.ok(warnings[0].includes('--disable-experiments'));
+	});
+
+	it('warns when the welcome page is requested against --skip-welcome', () => {
+		const warnings = flagConflictWarnings({ 'workbench.startupEditor': 'welcomePage' });
+		assert.strictEqual(warnings.length, 1);
+		assert.ok(warnings[0].includes('--skip-welcome'));
+	});
+
+	it('ignores unrelated settings', () => {
+		assert.deepStrictEqual(flagConflictWarnings({ 'editor.fontSize': 20, 'workbench.startupEditor': 'none' }), []);
+	});
+
+	it('reports multiple conflicts at once', () => {
+		const warnings = flagConflictWarnings({ 'security.workspace.trust.enabled': true, 'update.mode': 'manual' });
+		assert.strictEqual(warnings.length, 2);
+	});
+});
+
+describe('validateUserDataDirLength', () => {
+	it('accepts a short settings dir on darwin', () => {
+		assert.strictEqual(validateUserDataDirLength('/tmp/test-resources/settings', 'darwin'), undefined);
+	});
+
+	it('rejects a settings dir whose IPC socket path would exceed the darwin limit', () => {
+		const dir = '/' + 'a'.repeat(100);
+		const message = validateUserDataDirLength(dir, 'darwin');
+		assert.ok(message, 'expected an error message');
+		assert.ok(message.includes(dir), 'message should name the offending directory');
+		assert.ok(/storage|TEST_RESOURCES/.test(message), 'message should point at the storage options');
+	});
+
+	it('allows linux a few more bytes than darwin', () => {
+		// socket path length lands between the darwin (104) and linux (108) limits
+		const dir = '/' + 'a'.repeat(89);
+		assert.ok(validateUserDataDirLength(dir, 'darwin'), 'should exceed the darwin limit');
+		assert.strictEqual(validateUserDataDirLength(dir, 'linux'), undefined);
+	});
+
+	it('never complains on windows (named pipes, no socket path limit)', () => {
+		assert.strictEqual(validateUserDataDirLength('C:\\' + 'a'.repeat(300), 'win32'), undefined);
 	});
 });
 

--- a/packages/extester/src/test/config.test.ts
+++ b/packages/extester/src/test/config.test.ts
@@ -138,11 +138,14 @@ describe('loadConfig', () => {
 
 	describe('path resolution', () => {
 		it('resolves relative paths in setup section relative to config file directory', async () => {
-			const { dir, file } = makeTmpConfig(JSON.stringify({ setup: { storage: './test-resources', extensionsDir: './test-extensions' } }));
+			const { dir, file } = makeTmpConfig(
+				JSON.stringify({ setup: { storage: './test-resources', extensionsDir: './test-extensions', settings: './vscode-settings.json' } }),
+			);
 			try {
 				const cfg = await loadConfig(file);
 				assert.strictEqual(cfg.setup?.storage, path.resolve(dir, 'test-resources'));
 				assert.strictEqual(cfg.setup?.extensionsDir, path.resolve(dir, 'test-extensions'));
+				assert.strictEqual(cfg.setup?.settings, path.resolve(dir, 'vscode-settings.json'));
 			} finally {
 				fs.rmSync(dir, { recursive: true });
 			}

--- a/packages/extester/src/util/codeUtil.ts
+++ b/packages/extester/src/util/codeUtil.ts
@@ -71,6 +71,94 @@ export function overriddenDefaultKeys(defaults: Record<string, unknown>, custom:
 	return Object.keys(custom).filter((key) => key in defaults && defaults[key] !== custom[key]);
 }
 
+/**
+ * Check whether a folder about to be opened carries workspace settings
+ * (`.vscode/settings.json`) that shadow user-supplied custom settings.
+ * Workspace scope wins over user scope in VS Code, so a shadowed custom
+ * setting silently stops applying the moment the folder is opened — while
+ * the injected user-scope settings.json still shows the custom value.
+ *
+ * Best-effort: unreadable or malformed workspace files yield no results,
+ * never an error.
+ *
+ * @param resourcePath path to the resource being opened
+ * @param custom the user-supplied custom settings
+ * @returns the shadowed keys with the workspace value that wins
+ */
+export function findShadowedSettings(resourcePath: string, custom: Record<string, unknown>): { key: string; workspaceValue: unknown }[] {
+	try {
+		if (!fs.statSync(resourcePath).isDirectory()) {
+			return [];
+		}
+		const workspaceFile = path.join(resourcePath, '.vscode', 'settings.json');
+		if (!fs.existsSync(workspaceFile)) {
+			return [];
+		}
+		// lenient parse: workspace files are JSONC and may be malformed — this
+		// only powers a warning, so never let it fail the run
+		const workspace: unknown = parseJsonc(fs.readFileSync(workspaceFile).toString(), [], { allowTrailingComma: true });
+		if (workspace === null || typeof workspace !== 'object' || Array.isArray(workspace)) {
+			return [];
+		}
+		const workspaceSettings = workspace as Record<string, unknown>;
+		return Object.keys(custom)
+			.filter((key) => key in workspaceSettings && workspaceSettings[key] !== custom[key])
+			.map((key) => ({ key, workspaceValue: workspaceSettings[key] }));
+	} catch {
+		return [];
+	}
+}
+
+/**
+ * Settings that ExTester's always-on launch flags override regardless of what
+ * settings.json says. CLI flags take precedence over settings in VS Code, so a
+ * custom value trying to re-enable one of these features is silently dead.
+ */
+const FLAG_SHADOWED_SETTINGS: { key: string; flag: string; conflicts: (value: unknown) => boolean }[] = [
+	{ key: 'security.workspace.trust.enabled', flag: '--disable-workspace-trust', conflicts: (value) => value === true },
+	{ key: 'update.mode', flag: '--disable-updates', conflicts: (value) => value !== 'none' },
+	{ key: 'telemetry.telemetryLevel', flag: '--disable-telemetry', conflicts: (value) => value !== 'off' },
+	{ key: 'workbench.enableExperiments', flag: '--disable-experiments', conflicts: (value) => value === true },
+	{ key: 'workbench.startupEditor', flag: '--skip-welcome', conflicts: (value) => value === 'welcomePage' },
+];
+
+/**
+ * List warnings for custom settings that have no effect because an always-on
+ * ExTester launch flag overrides them (CLI flags win over settings.json).
+ */
+export function flagConflictWarnings(custom: Record<string, unknown>): string[] {
+	return FLAG_SHADOWED_SETTINGS.filter(({ key, conflicts }) => key in custom && conflicts(custom[key])).map(
+		({ key, flag }) => `${key}=${JSON.stringify(custom[key])} has no effect: overridden by the always-on launch flag ${flag}`,
+	);
+}
+
+/**
+ * Check that VS Code's IPC socket inside the user data dir fits the OS
+ * AF_UNIX path limit (~104 bytes on macOS, ~108 on Linux). A too-deep
+ * storage path makes the VS Code main process die instantly with
+ * `listen EINVAL`, which ChromeDriver only surfaces as the cryptic
+ * "session not created: Chrome instance exited".
+ *
+ * @param settingsDir the directory passed as --user-data-dir
+ * @param platform target platform, defaults to the current one
+ * @returns an actionable error message, or undefined when the path fits
+ */
+export function validateUserDataDirLength(settingsDir: string, platform: NodeJS.Platform = process.platform): string | undefined {
+	if (platform === 'win32') {
+		return undefined;
+	}
+	// widest socket name VS Code creates in the dir, e.g. "1.135-main.sock"
+	const socketPath = `${settingsDir}/9.999-main.sock`;
+	const limit = platform === 'darwin' ? 103 : 107;
+	if (Buffer.byteLength(socketPath) > limit) {
+		return (
+			`The storage path is too long for VS Code's IPC socket (${Buffer.byteLength(socketPath)} > ${limit} bytes): ${settingsDir}\n` +
+			`VS Code would fail to start with "Chrome instance exited". Use a shorter storage folder via -s/--storage or the TEST_RESOURCES environment variable.`
+		);
+	}
+	return undefined;
+}
+
 /** defaults for the [[RunOptions]] */
 export const DEFAULT_RUN_OPTIONS = {
 	vscodeVersion: 'latest',
@@ -316,6 +404,26 @@ export class CodeUtil {
 		}
 		command += ` --user-data-dir="${path.join(this.downloadFolder, 'settings')}"`;
 		childProcess.execSync(command, { stdio: 'inherit', timeout: 120_000 });
+	}
+
+	/**
+	 * Write user-supplied custom settings into the test instance's user data
+	 * dir so that CLI-driven steps running before the browser starts (e.g.
+	 * marketplace extension installs, which honor settings like `http.proxy`)
+	 * see them too. `VSBrowser.start()` later wipes the dir and rewrites the
+	 * file merged with the framework defaults.
+	 *
+	 * @param settingsPath path to the custom settings file; no-op when empty
+	 */
+	writeUserSettings(settingsPath: string): void {
+		if (!settingsPath) {
+			return;
+		}
+		const settings = this.parseSettings(settingsPath);
+		const target = path.join(this.downloadFolder, 'settings', 'User', 'settings.json');
+		fs.mkdirpSync(path.dirname(target));
+		fs.writeJSONSync(target, settings, { spaces: '\t' });
+		console.log(`Writing code settings for setup phase to ${target}`);
 	}
 
 	/**


### PR DESCRIPTION
## What

Follow-up to #2483: makes the remaining silent failure modes of `--code_settings` propagation visible or impossible.

- **Workspace shadowing warning** — custom settings are written at *user* scope, so a folder opened via `--open_resource` or `openResources()` whose `.vscode/settings.json` defines the same key silently wins per VS Code's precedence — the classic "my setting worked until the window reloaded" trap, while the injected settings.json still shows the custom value. `findShadowedSettings()` now runs for launch resources and every `openResources()` call and warns with the workspace file path and the shadowed keys (`custom -> workspace` values). Best-effort: malformed or JSONC workspace files never fail the run.
- **Launch-flag conflict warning** — CLI flags beat settings.json, so custom settings trying to re-enable what the always-on flags disable (workspace trust, updates, telemetry, experiments, welcome page) were silently dead. `flagConflictWarnings()` names the setting and the flag that overrides it.
- **Setup-phase settings** — settings.json was only written at browser start, so CLI-driven setup steps never saw custom settings (e.g. `http.proxy` for marketplace installs). `CodeUtil.writeUserSettings()` now writes them before setup steps; `setup-tests` gains `-o/--code_settings` (config: `setup.settings`, with schema + relative path resolution), and `setup-and-run` reuses the run-phase settings for its setup phase.
- **Storage path preflight** — the user data dir hosts VS Code's IPC socket, capped by AF_UNIX path limits (~104 bytes macOS, ~108 Linux). A too-deep storage path made VS Code die instantly, surfaced by ChromeDriver only as `session not created: Chrome instance exited`. `validateUserDataDirLength()` now fails fast in `VSBrowser.start()` with a message pointing at `-s/--storage` / `TEST_RESOURCES`.
- **Docs** — new "How custom settings propagate" section in Test-Setup.md: the injected defaults table (with why each is set) and the full precedence chain (defaults → custom file → launch flags → workspace settings).

## Testing

- 23 new unit tests written test-first (TDD): `findShadowedSettings` (7, incl. JSONC and malformed workspace files), `flagConflictWarnings` (9), `validateUserDataDirLength` (4, per-platform limits), `CodeUtil.writeUserSettings` (3), plus `setup.settings` path resolution in the config loader. Full `test:unit` suite: 107 passing.
- Verified live on VS Code 1.135.0 via the real CLI: one run printed all three warnings with exact key diffs (override, flag conflict, and workspace shadowing naming the folder's settings file) while the assertions on the actual UI state passed; a second run against a 228-byte storage path failed fast with the actionable path-length error instead of the cryptic ChromeDriver message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)