### PR TITLE
feat(extester): seed keybindings and snippets, harden the settings-dir wipe, guard merge invariants

### DIFF
--- a/docs/Test-Setup.md
+++ b/docs/Test-Setup.md
@@ -138,6 +138,8 @@ Options:
   -c, --code_version <version>                 # Version of VS Code to be used
   -t, --type <type>                            # Type of VS Code release (stable/insider)
   -o, --code_settings <settings.json>          # Path to custom settings for VS Code json file
+  --code_keybindings <keybindings.json>        # Path to a custom keybindings.json file (JSONC array) seeded into the test instance
+  --code_snippets <folder>                     # Path to a folder of snippet files seeded into the test instance's User/snippets
   -u, --uninstall_extension                    # Uninstall the extension after the test run (default: false)
   -m, --mocha_config <mocharc.js>              # Path to Mocha configuration file
   -l, --log_level <level>                      # Log messages from webdriver with a given level (default: "Info")
@@ -164,6 +166,8 @@ Options:
   -c, --code_version <version>                 # Version of VS Code to download
   -t, --type <type>                            # Type of VS Code release (stable/insider)
   -o, --code_settings <settings.json>          # Path to custom settings for VS Code json file
+  --code_keybindings <keybindings.json>        # Path to a custom keybindings.json file (JSONC array) seeded into the test instance
+  --code_snippets <folder>                     # Path to a folder of snippet files seeded into the test instance's User/snippets
   --package_options <json>                     # JSON string of vsce IPackageOptions (e.g. '{"useYarn":true,"followSymlinks":true}')
   -u, --uninstall_extension                    # Uninstall the extension after the test run (default: false)
   -m, --mocha_config <mocharc.js>              # Path to Mocha configuration file
@@ -205,6 +209,8 @@ Two things outrank your settings file:
 2. **Workspace settings.** Your file is written at _user_ scope. Any folder or workspace you open — via `-r`/`--open_resource` or `VSBrowser.openResources()` — that carries its own `.vscode/settings.json` shadows your value for the keys it defines, per VS Code's normal precedence. This is the classic "my setting worked until the window reloaded" trap: opening a folder reloads the window, and the folder's workspace settings take over — while the user-scope file on disk still shows your value. ExTester prints a warning naming the shadowed keys when this happens.
 
 Custom settings are applied at launch. To change a setting mid-test, use the `SettingsEditor` page object.
+
+Keybindings and snippets can be seeded the same way: `--code_keybindings <keybindings.json>` copies a JSONC keybindings file (array root, comments preserved) into the test instance, and `--code_snippets <folder>` copies a folder of snippet files (`<language>.json` or `*.code-snippets`) into `User/snippets`. Seeding matters because ExTester wipes the settings directory on every start for determinism — only `languagepacks.json` is preserved (it is written by the extension-install step and needed for locale testing), so files placed there manually do not survive. If the wipe hits a busy directory (a leftover process from a previous run), ExTester retries once and then fails with a clear error instead of continuing with mixed state.
 
 `setup-tests` also accepts `-o`/`--code_settings` (config: `setup.settings`): the parsed settings are written before setup-phase CLI steps run, so settings such as `http.proxy` apply to marketplace extension installs. `setup-and-run` reuses the run-phase settings for its setup phase automatically.
 
@@ -322,6 +328,8 @@ Controls test execution inside VS Code. Used by `run-tests` and `setup-and-run`.
 | `storage`           | string                    | `$TEST_RESOURCES` or `$TMPDIR/test-resources` | `-s` / `--storage`             | Folder for all downloaded test resources                                                                                                                                                                       |
 | `extensionsDir`     | string                    | —                                             | `-e` / `--extensions_dir`      | VS Code extensions directory override                                                                                                                                                                          |
 | `settings`          | string                    | —                                             | `-o` / `--code_settings`       | Path to a custom VS Code `settings.json`. See [How custom settings propagate](#how-custom-settings-propagate)                                                                                                  |
+| `keybindings`       | string                    | —                                             | `--code_keybindings`           | Custom `keybindings.json` (JSONC array) seeded into the test instance                                                                                                                                          |
+| `snippets`          | string                    | —                                             | `--code_snippets`              | Folder of snippet files seeded into the test instance's `User/snippets`                                                                                                                                        |
 | `cleanup`           | boolean                   | `false`                                       | `-u` / `--uninstall_extension` | Uninstall the extension after the test run                                                                                                                                                                     |
 | `mochaConfig`       | string                    | —                                             | `-m` / `--mocha_config`        | Path to a Mocha configuration file                                                                                                                                                                             |
 | `logLevel`          | string                    | `"Info"`                                      | `-l` / `--log_level`           | Webdriver and ChromeDriver log level: `Debug`, `Info`, `Warning`, `Severe`, `OFF`, `ALL` (`ALL` records the full CDP wire traffic in `chromedriver.log` and can grow it by hundreds of MB over a long session) |

--- a/packages/extester/resources/extester.schema.json
+++ b/packages/extester/resources/extester.schema.json
@@ -275,6 +275,16 @@
           "description": "Path to a custom VS Code settings.json file to apply during the test run.",
           "examples": ["./vscode-settings.json"]
         },
+        "keybindings": {
+          "type": "string",
+          "description": "Path to a custom VS Code keybindings.json file (JSONC array) seeded into the test instance.",
+          "examples": ["./vscode-keybindings.json"]
+        },
+        "snippets": {
+          "type": "string",
+          "description": "Path to a folder of snippet files seeded into the test instance's User/snippets directory.",
+          "examples": ["./my-snippets"]
+        },
         "cleanup": {
           "type": "boolean",
           "description": "Uninstall the extension under test after the test run completes.",

--- a/packages/extester/src/browser.ts
+++ b/packages/extester/src/browser.ts
@@ -18,7 +18,6 @@
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import * as fs from 'fs-extra';
-import { satisfies } from 'compare-versions';
 import { WebDriver, Builder, initPageObjects, logging, By, Browser, EditorView, Workbench } from '@redhat-developer/page-objects';
 import { Options, ServiceBuilder } from 'selenium-webdriver/chrome';
 import { getLocatorsPath } from '@redhat-developer/locators';
@@ -26,7 +25,12 @@ import {
 	CodeUtil,
 	CustomPageObjectsOptions,
 	ReleaseQuality,
+	SeedFilesOptions,
 	findShadowedSettings,
+	getDefaultSettings,
+	seedKeybindingsFile,
+	seedSnippetsDir,
+	removeDirWithRetry,
 	flagConflictWarnings,
 	overriddenDefaultKeys,
 	validateUserDataDirLength,
@@ -46,6 +50,7 @@ export class VSBrowser {
 	private readonly logLevel: logging.Level;
 	private readonly customPageObjects?: CustomPageObjectsOptions;
 	private readonly locale: string;
+	private readonly seedFiles?: SeedFilesOptions;
 	private static _instance: VSBrowser;
 	private readonly _startTimestamp: string;
 	private static _signalHandlersRegistered = false;
@@ -62,6 +67,7 @@ export class VSBrowser {
 		logLevel: logging.Level = logging.Level.INFO,
 		customPageObjects?: CustomPageObjectsOptions,
 		locale: string = '',
+		seedFiles?: SeedFilesOptions,
 	) {
 		this.storagePath = process.env.TEST_RESOURCES ? process.env.TEST_RESOURCES : path.resolve(DEFAULT_STORAGE_FOLDER);
 		this.extensionsFolder = process.env.EXTENSIONS_FOLDER ? process.env.EXTENSIONS_FOLDER : undefined;
@@ -71,6 +77,7 @@ export class VSBrowser {
 		this.logLevel = logLevel;
 		this.customPageObjects = customPageObjects;
 		this.locale = locale;
+		this.seedFiles = seedFiles;
 		this._startTimestamp = this.formatTimestamp(new Date());
 
 		VSBrowser._instance = this;
@@ -108,60 +115,21 @@ export class VSBrowser {
 		}
 
 		if (fs.existsSync(userSettings)) {
-			try {
-				fs.removeSync(settingsDir);
-			} catch (e: unknown) {
-				const code = (e as NodeJS.ErrnoException).code;
-				if (code === 'EBUSY' || code === 'EPERM') {
-					console.warn(`Could not fully clean settings dir (${code}), continuing anyway.`);
-				} else {
-					throw e;
-				}
-			}
+			// A busy dir gets one retry, then a hard failure: continuing with a
+			// half-wiped settings dir means nondeterministic leftover state.
+			await removeDirWithRetry(settingsDir);
 		}
 
-		let defaultSettings = {
-			// Never let the tested VS Code instance update itself mid-run: on macOS
-			// the background updater replaces application files while tests execute,
-			// which manifests as "Your Code installation appears to be corrupt" and a
-			// dead extension host ("version mismatch") partway through a session.
-			'update.mode': 'none',
-			'update.showReleaseNotes': false,
-			'extensions.autoUpdate': false,
-			'extensions.autoCheckUpdates': false,
-			'workbench.editor.enablePreview': false,
-			'workbench.startupEditor': 'none',
-			'window.titleBarStyle': 'custom',
-			'window.commandCenter': false,
-			'window.dialogStyle': 'custom',
-			'window.restoreFullscreen': true,
-			'window.newWindowDimensions': 'maximized',
-			'security.workspace.trust.enabled': false,
-			'files.simpleDialog.enable': true,
-			'terminal.integrated.copyOnSelection': true,
-			'workbench.secondarySideBar.defaultVisibility': 'hidden',
-			'workbench.welcomePage.experimentalOnboarding': false,
-			'workbench.welcomePage.walkthroughs.openOnInstall': false,
-			'workbench.editor.useModal': 'off',
-			// Disable workbench animations: VS Code >=1.133 fades the quick input
-			// out over 0.15s on close, so an isDisplayed() check right after
-			// accepting a pick still sees the widget. Whether motion is on depends
-			// on the OS reduced-motion preference (GitHub windows/macos runners
-			// report it, Xvfb linux does not), making runs environment-dependent.
-			'workbench.reduceMotion': 'on',
-			...(satisfies(this.codeVersion, '>=1.101.0') ? { 'window.menuStyle': 'custom' } : {}),
-		};
+		let mergedSettings: Record<string, unknown> = getDefaultSettings(this.codeVersion);
 		if (Object.keys(this.customSettings).length > 0) {
 			console.log('Detected user defined code settings');
 			// Several defaults are load-bearing for the framework itself (e.g. custom
 			// title bar and dialogs for the page objects, reduced motion for stable
 			// waits, disabled updates) — make it visible when custom settings change them.
 			const custom = this.customSettings as Record<string, unknown>;
-			const overridden = overriddenDefaultKeys(defaultSettings, custom);
+			const overridden = overriddenDefaultKeys(mergedSettings, custom);
 			if (overridden.length > 0) {
-				const diff = overridden.map(
-					(key) => `${key} (${JSON.stringify(defaultSettings[key as keyof typeof defaultSettings])} -> ${JSON.stringify(custom[key])})`,
-				);
+				const diff = overridden.map((key) => `${key} (${JSON.stringify(mergedSettings[key])} -> ${JSON.stringify(custom[key])})`);
 				console.log('\x1b[33m%s\x1b[0m', `WARNING: Custom settings override framework defaults: ${diff.join(', ')}`);
 			}
 			// CLI flags beat settings.json in VS Code, so settings trying to
@@ -169,14 +137,21 @@ export class VSBrowser {
 			for (const warning of flagConflictWarnings(custom)) {
 				console.log('\x1b[33m%s\x1b[0m', `WARNING: ${warning}`);
 			}
-			defaultSettings = { ...defaultSettings, ...this.customSettings };
+			mergedSettings = { ...mergedSettings, ...this.customSettings };
 		}
 
 		fs.mkdirpSync(path.join(userSettings, 'globalStorage'));
 		// tab indentation matches how VS Code itself writes settings.json and keeps
 		// the file readable when debugging which settings were actually applied
-		fs.writeJSONSync(path.join(userSettings, 'settings.json'), defaultSettings, { spaces: '\t' });
+		fs.writeJSONSync(path.join(userSettings, 'settings.json'), mergedSettings, { spaces: '\t' });
 		console.log(`Writing code settings to ${path.join(userSettings, 'settings.json')}`);
+
+		if (this.seedFiles?.keybindings) {
+			seedKeybindingsFile(this.seedFiles.keybindings, userSettings);
+		}
+		if (this.seedFiles?.snippets) {
+			seedSnippetsDir(this.seedFiles.snippets, userSettings);
+		}
 
 		if (this.locale) {
 			fs.writeJSONSync(path.join(userSettings, 'locale.json'), { locale: this.locale, osLocale: this.locale });

--- a/packages/extester/src/cli.ts
+++ b/packages/extester/src/cli.ts
@@ -175,6 +175,8 @@ program
 	.option('-c, --code_version <version>', 'Version of VS Code to be used, use `min`/`max` to download the oldest/latest VS Code supported by ExTester')
 	.option('-t, --type <type>', 'Type of VS Code release (stable/insider)')
 	.option('-o, --code_settings <settings.json>', 'Path to custom settings for VS Code json file')
+	.option('--code_keybindings <keybindings.json>', 'Path to a custom keybindings.json file (JSONC array) seeded into the test instance')
+	.option('--code_snippets <folder>', "Path to a folder of snippet files seeded into the test instance's User/snippets")
 	.option('-u, --uninstall_extension', 'Uninstall the extension after the test run', false)
 	.option('-m, --mocha_config <mocharc.js>', 'Path to Mocha configuration file')
 	.option('-l, --log_level <level>', 'Log messages from webdriver with a given level', 'Info')
@@ -202,6 +204,8 @@ program
 			await extest.runTests(files, {
 				vscodeVersion: cmd.code_version ?? run.vscodeVersion,
 				settings: cmd.code_settings ?? run.settings,
+				keybindings: cmd.code_keybindings ?? run.keybindings,
+				snippets: cmd.code_snippets ?? run.snippets,
 				cleanup: cmd.uninstall_extension || run.cleanup,
 				config: cmd.mocha_config ?? run.mochaConfig,
 				logLevel: cmd.log_level ?? run.logLevel,
@@ -221,6 +225,8 @@ program
 	.option('-c, --code_version <version>', 'Version of VS Code to download, use `min`/`max` to download the oldest/latest VS Code supported by ExTester')
 	.option('-t, --type <type>', 'Type of VS Code release (stable/insider)')
 	.option('-o, --code_settings <settings.json>', 'Path to custom settings for VS Code json file')
+	.option('--code_keybindings <keybindings.json>', 'Path to a custom keybindings.json file (JSONC array) seeded into the test instance')
+	.option('--code_snippets <folder>', "Path to a folder of snippet files seeded into the test instance's User/snippets")
 	.option('--package_options <json>', 'JSON string of vsce IPackageOptions passed to vsce.createVSIX() (e.g. \'{"useYarn":true,"followSymlinks":true}\')')
 	.option('-u, --uninstall_extension', 'Uninstall the extension after the test run', false)
 	.option('-m, --mocha_config <mocharc.js>', 'Path to Mocha configuration file')
@@ -261,6 +267,8 @@ program
 				},
 				{
 					settings: cmd.code_settings ?? run.settings,
+					keybindings: cmd.code_keybindings ?? run.keybindings,
+					snippets: cmd.code_snippets ?? run.snippets,
 					cleanup: cmd.uninstall_extension || run.cleanup,
 					config: cmd.mocha_config ?? run.mochaConfig,
 					logLevel: cmd.log_level ?? run.logLevel,

--- a/packages/extester/src/config.ts
+++ b/packages/extester/src/config.ts
@@ -60,6 +60,10 @@ export interface ExTesterRunConfig {
 	extensionsDir?: string;
 	/** Path to a custom VS Code `settings.json` file to use during the test run. */
 	settings?: string;
+	/** Path to a custom VS Code `keybindings.json` file (JSONC array) seeded into the test instance. */
+	keybindings?: string;
+	/** Path to a folder of snippet files seeded into the test instance's `User/snippets`. */
+	snippets?: string;
 	/** Uninstall the extension under test after the test run completes. Defaults to `false`. */
 	cleanup?: boolean;
 	/** Path to a Mocha configuration file (e.g. `.mocharc.js`). */
@@ -108,7 +112,7 @@ export interface ExTesterConfig {
 const SETUP_PATH_KEYS: (keyof ExTesterSetupConfig)[] = ['storage', 'extensionsDir', 'settings'];
 
 /** Path-valued keys in ExTesterRunConfig that must be resolved relative to the config file. */
-const RUN_PATH_KEYS: (keyof ExTesterRunConfig)[] = ['storage', 'extensionsDir', 'settings', 'mochaConfig', 'customPageObjects'];
+const RUN_PATH_KEYS: (keyof ExTesterRunConfig)[] = ['storage', 'extensionsDir', 'settings', 'keybindings', 'snippets', 'mochaConfig', 'customPageObjects'];
 
 /** Path-valued array keys in ExTesterRunConfig whose entries are plain paths (not glob patterns). */
 const RUN_PATH_ARRAY_KEYS: (keyof ExTesterRunConfig)[] = ['resources'];

--- a/packages/extester/src/suite/runner.ts
+++ b/packages/extester/src/suite/runner.ts
@@ -19,7 +19,7 @@ import { VSBrowser } from '../browser';
 import * as fs from 'fs-extra';
 import Mocha from 'mocha';
 import { globSync } from 'glob';
-import { CodeUtil, CustomPageObjectsOptions, ReleaseQuality } from '../util/codeUtil';
+import { CodeUtil, CustomPageObjectsOptions, ReleaseQuality, SeedFilesOptions } from '../util/codeUtil';
 import * as path from 'node:path';
 import * as yaml from 'js-yaml';
 import sanitize from 'sanitize-filename';
@@ -39,6 +39,7 @@ export class VSRunner {
 	private readonly releaseType: ReleaseQuality;
 	private readonly customPageObjects?: CustomPageObjectsOptions;
 	private readonly locale: string | undefined;
+	private readonly seedFiles?: SeedFilesOptions;
 	private readonly tmpLink = path.join(os.tmpdir(), 'extest-code');
 
 	constructor(
@@ -50,6 +51,7 @@ export class VSRunner {
 		customSettings: object = {},
 		cleanup: boolean = false,
 		locale?: string,
+		seedFiles?: SeedFilesOptions,
 	) {
 		const conf = this.loadConfig(config);
 		this.mocha = new Mocha(conf);
@@ -60,6 +62,7 @@ export class VSRunner {
 		this.releaseType = releaseType;
 		this.customPageObjects = customPageObjects;
 		this.locale = locale;
+		this.seedFiles = seedFiles;
 	}
 
 	/**
@@ -71,7 +74,15 @@ export class VSRunner {
 	runTests(testFilesPattern: string[], code: CodeUtil, resources: string[], logLevel: logging.Level = logging.Level.INFO): Promise<number> {
 		return new Promise((resolve, reject) => {
 			const self = this;
-			const browser: VSBrowser = new VSBrowser(this.codeVersion, this.releaseType, this.customSettings, logLevel, this.customPageObjects, this.locale);
+			const browser: VSBrowser = new VSBrowser(
+				this.codeVersion,
+				this.releaseType,
+				this.customSettings,
+				logLevel,
+				this.customPageObjects,
+				this.locale,
+				this.seedFiles,
+			);
 			let coverage: Coverage | undefined;
 
 			const testFiles = new Set<string>();

--- a/packages/extester/src/test/codeUtil.test.ts
+++ b/packages/extester/src/test/codeUtil.test.ts
@@ -21,7 +21,17 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as vsce from '@vscode/vsce';
 import type { IPackageOptions } from '@vscode/vsce';
-import { CodeUtil, overriddenDefaultKeys, validateUserDataDirLength, flagConflictWarnings, findShadowedSettings } from '../util/codeUtil';
+import {
+	CodeUtil,
+	getDefaultSettings,
+	overriddenDefaultKeys,
+	removeDirWithRetry,
+	seedKeybindingsFile,
+	seedSnippetsDir,
+	validateUserDataDirLength,
+	flagConflictWarnings,
+	findShadowedSettings,
+} from '../util/codeUtil';
 import { ReleaseQuality } from '../util/codeUtil';
 import { Download } from '../util/download';
 
@@ -142,6 +152,175 @@ describe('CodeUtil.parseSettings', () => {
 	it('throws a readable error for an unreadable file', () => {
 		const util = new CodeUtil(dir, ReleaseQuality.Stable) as unknown as WithParseSettings;
 		assert.throws(() => util.parseSettings(path.join(dir, 'missing.json')), /Unable to read settings/);
+	});
+});
+
+describe('getDefaultSettings', () => {
+	it('keeps every framework default scalar so the shallow custom-settings merge stays faithful', () => {
+		// VS Code replaces object-valued settings whole at each scope, so the
+		// shallow spread in VSBrowser.start() is only correct while no default
+		// has an object or array value. This test guards that invariant.
+		for (const [key, value] of Object.entries(getDefaultSettings('1.135.0'))) {
+			assert.ok(value === null || typeof value !== 'object', `default '${key}' must not have an object/array value`);
+		}
+	});
+
+	it('uses the current enum form for extensions.autoUpdate to avoid the VS Code migration rewrite', () => {
+		assert.strictEqual(getDefaultSettings('1.135.0')['extensions.autoUpdate'], 'off');
+	});
+
+	it('gates window.menuStyle on VS Code >= 1.101.0', () => {
+		assert.strictEqual(getDefaultSettings('1.100.0')['window.menuStyle'], undefined);
+		assert.strictEqual(getDefaultSettings('1.101.0')['window.menuStyle'], 'custom');
+	});
+
+	it('replaces object-valued custom settings whole in the merge, like VS Code scopes do', () => {
+		const merged = { ...getDefaultSettings('1.135.0'), ...{ 'files.exclude': { '**/out': true } } };
+		assert.deepStrictEqual(merged['files.exclude'], { '**/out': true });
+	});
+});
+
+describe('removeDirWithRetry', () => {
+	// stub via the underlying CJS module object — the TS namespace import wrapper
+	// exposes re-exports through getters and cannot be assigned to
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	const fsModule = require('fs-extra') as { removeSync: (dir: string) => void };
+	let dir: string;
+	const originalRemoveSync = fsModule.removeSync;
+
+	beforeEach(async () => {
+		dir = await fs.mkdtemp(path.join(os.tmpdir(), 'extest-wipe-'));
+	});
+
+	afterEach(async () => {
+		fsModule.removeSync = originalRemoveSync;
+		await fs.remove(dir);
+	});
+
+	function busyError(): NodeJS.ErrnoException {
+		const err: NodeJS.ErrnoException = new Error('EBUSY: resource busy or locked');
+		err.code = 'EBUSY';
+		return err;
+	}
+
+	it('removes an existing directory', async () => {
+		fs.outputFileSync(path.join(dir, 'User', 'settings.json'), '{}');
+		await removeDirWithRetry(dir);
+		assert.strictEqual(fs.existsSync(dir), false);
+	});
+
+	it('retries once when the first removal reports EBUSY', async () => {
+		let calls = 0;
+		fsModule.removeSync = (target: string) => {
+			calls++;
+			if (calls === 1) {
+				throw busyError();
+			}
+			originalRemoveSync(target);
+		};
+		await removeDirWithRetry(dir);
+		assert.strictEqual(calls, 2);
+		assert.strictEqual(fs.existsSync(dir), false);
+	});
+
+	it('fails loudly when EBUSY persists after the retry', async () => {
+		fsModule.removeSync = () => {
+			throw busyError();
+		};
+		await assert.rejects(() => removeDirWithRetry(dir), /Could not clean the settings directory.*EBUSY/s);
+	});
+});
+
+describe('seedKeybindingsFile', () => {
+	let dir: string;
+	let userDir: string;
+
+	beforeEach(async () => {
+		dir = await fs.mkdtemp(path.join(os.tmpdir(), 'extest-keybindings-'));
+		userDir = path.join(dir, 'User');
+		fs.mkdirpSync(userDir);
+	});
+
+	afterEach(async () => {
+		await fs.remove(dir);
+	});
+
+	it('copies a JSONC keybindings file verbatim, preserving comments', () => {
+		const source = path.join(dir, 'my-keybindings.json');
+		const content = '[\n\t// run tests\n\t{ "key": "ctrl+t", "command": "workbench.action.tasks.test" },\n]';
+		fs.writeFileSync(source, content);
+		seedKeybindingsFile(source, userDir);
+		assert.strictEqual(fs.readFileSync(path.join(userDir, 'keybindings.json'), 'utf-8'), content);
+	});
+
+	it('rejects a keybindings file whose root is not an array', () => {
+		const source = path.join(dir, 'object.json');
+		fs.writeFileSync(source, '{ "key": "ctrl+t" }');
+		assert.throws(() => seedKeybindingsFile(source, userDir), /must contain a JSON array at the root.*object/);
+	});
+
+	it('rejects a malformed keybindings file naming the file', () => {
+		const source = path.join(dir, 'broken.json');
+		fs.writeFileSync(source, '[{ "key": ]');
+		assert.throws(
+			() => seedKeybindingsFile(source, userDir),
+			(err: Error) => err.message.includes(source),
+		);
+	});
+
+	it('rejects a missing keybindings file with a readable error', () => {
+		assert.throws(() => seedKeybindingsFile(path.join(dir, 'missing.json'), userDir), /Unable to read keybindings/);
+	});
+});
+
+describe('seedSnippetsDir', () => {
+	let dir: string;
+	let userDir: string;
+
+	beforeEach(async () => {
+		dir = await fs.mkdtemp(path.join(os.tmpdir(), 'extest-snippets-'));
+		userDir = path.join(dir, 'User');
+		fs.mkdirpSync(userDir);
+	});
+
+	afterEach(async () => {
+		await fs.remove(dir);
+	});
+
+	it('copies snippet files into User/snippets', () => {
+		const source = path.join(dir, 'my-snippets');
+		fs.outputFileSync(path.join(source, 'typescript.json'), '{}');
+		fs.outputFileSync(path.join(source, 'global.code-snippets'), '{}');
+		seedSnippetsDir(source, userDir);
+		assert.ok(fs.existsSync(path.join(userDir, 'snippets', 'typescript.json')));
+		assert.ok(fs.existsSync(path.join(userDir, 'snippets', 'global.code-snippets')));
+	});
+
+	it('rejects a path that is not a directory', () => {
+		const file = path.join(dir, 'not-a-dir.json');
+		fs.writeFileSync(file, '{}');
+		assert.throws(() => seedSnippetsDir(file, userDir), /must be a directory/);
+	});
+
+	it('rejects a missing snippets directory with a readable error', () => {
+		assert.throws(() => seedSnippetsDir(path.join(dir, 'missing'), userDir), /Unable to read snippets/);
+	});
+});
+
+describe('CodeUtil.uninstallExtension', () => {
+	it('is a no-op without touching package.json when cleanup is off', async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'extest-no-pjson-'));
+		const orig = process.cwd();
+		process.chdir(dir);
+		try {
+			const util = new CodeUtil(dir, ReleaseQuality.Stable);
+			// must not require ./package.json (absent here) when there is nothing to clean up
+			assert.doesNotThrow(() => util.uninstallExtension(false));
+			assert.doesNotThrow(() => util.uninstallExtension(undefined));
+		} finally {
+			process.chdir(orig);
+			await fs.remove(dir);
+		}
 	});
 });
 

--- a/packages/extester/src/test/config.test.ts
+++ b/packages/extester/src/test/config.test.ts
@@ -156,6 +156,8 @@ describe('loadConfig', () => {
 				JSON.stringify({
 					run: {
 						settings: './vscode-settings.json',
+						keybindings: './vscode-keybindings.json',
+						snippets: './my-snippets',
 						mochaConfig: './.mocharc.js',
 						customPageObjects: './out/locators.js',
 						testFiles: ['./out/**/*.test.js'],
@@ -168,6 +170,8 @@ describe('loadConfig', () => {
 			try {
 				const cfg = await loadConfig(file);
 				assert.strictEqual(cfg.run?.settings, path.resolve(dir, 'vscode-settings.json'));
+				assert.strictEqual(cfg.run?.keybindings, path.resolve(dir, 'vscode-keybindings.json'));
+				assert.strictEqual(cfg.run?.snippets, path.resolve(dir, 'my-snippets'));
 				assert.strictEqual(cfg.run?.mochaConfig, path.resolve(dir, '.mocharc.js'));
 				assert.strictEqual(cfg.run?.customPageObjects, path.resolve(dir, 'out/locators.js'));
 				assert.deepStrictEqual(cfg.run?.testFiles, [`${dirFwd}/out/**/*.test.js`]);

--- a/packages/extester/src/util/codeUtil.ts
+++ b/packages/extester/src/util/codeUtil.ts
@@ -19,6 +19,7 @@ import * as childProcess from 'child_process';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { parse as parseJsonc, printParseErrorCode, type ParseError } from 'jsonc-parser';
+import { satisfies } from 'compare-versions';
 import * as vsce from '@vscode/vsce';
 import type { IPackageOptions } from '@vscode/vsce';
 import { VSRunner } from '../suite/runner';
@@ -60,6 +61,147 @@ export interface RunOptions {
 	customPageObjects?: CustomPageObjectsOptions;
 	/** Display language locale for VS Code (e.g. 'ru', 'zh-cn', 'fr'). Requires the matching language pack extension to be installed. */
 	locale?: string;
+	/** path to a custom keybindings.json file (JSONC array) seeded into the test instance */
+	keybindings?: string;
+	/** path to a folder of snippet files seeded into the test instance's User/snippets */
+	snippets?: string;
+}
+
+/** User files seeded into the test instance's user data dir at startup */
+export interface SeedFilesOptions {
+	/** path to a custom keybindings.json file (JSONC array) */
+	keybindings?: string;
+	/** path to a folder of snippet files */
+	snippets?: string;
+}
+
+/**
+ * Validate and seed a custom keybindings file into the test instance's user
+ * dir. The file is JSONC (like VS Code's own keybindings.json) and must have
+ * an array root; it is copied verbatim so comments survive.
+ *
+ * @param sourcePath path to the user-supplied keybindings file
+ * @param userDir the `User` directory inside the test instance's user data dir
+ */
+export function seedKeybindingsFile(sourcePath: string, userDir: string): void {
+	let text = '';
+	try {
+		text = fs.readFileSync(sourcePath).toString();
+	} catch (err) {
+		throw new Error(`Unable to read keybindings from ${sourcePath}:\n ${err}`);
+	}
+	const errors: ParseError[] = [];
+	const parsed: unknown = parseJsonc(text, errors, { allowTrailingComma: true });
+	if (errors.length > 0) {
+		const { error, offset } = errors[0];
+		const line = text.slice(0, offset).split('\n').length;
+		throw new Error(`Error parsing the keybindings file from ${sourcePath}:\n ${printParseErrorCode(error)} at line ${line} (offset ${offset})`);
+	}
+	if (!Array.isArray(parsed)) {
+		const rootType = parsed === null ? 'null' : typeof parsed;
+		throw new Error(`Keybindings file ${sourcePath} must contain a JSON array at the root, got ${rootType}`);
+	}
+	fs.mkdirpSync(userDir);
+	fs.copyFileSync(sourcePath, path.join(userDir, 'keybindings.json'));
+	console.log(`Writing keybindings to ${path.join(userDir, 'keybindings.json')}`);
+}
+
+/**
+ * Seed a folder of snippet files into the test instance's `User/snippets`
+ * directory (both `<language>.json` and `*.code-snippets` files work there).
+ *
+ * @param sourceDir folder containing the snippet files
+ * @param userDir the `User` directory inside the test instance's user data dir
+ */
+export function seedSnippetsDir(sourceDir: string, userDir: string): void {
+	let stat: fs.Stats;
+	try {
+		stat = fs.statSync(sourceDir);
+	} catch (err) {
+		throw new Error(`Unable to read snippets from ${sourceDir}:\n ${err}`);
+	}
+	if (!stat.isDirectory()) {
+		throw new Error(`Snippets path ${sourceDir} must be a directory`);
+	}
+	const target = path.join(userDir, 'snippets');
+	fs.copySync(sourceDir, target);
+	console.log(`Writing snippets to ${target}`);
+}
+
+/**
+ * Remove a directory, retrying once after a short delay when the OS reports
+ * it busy (EBUSY/EPERM — typically a straggling process from a previous run
+ * still holding a handle). If the retry fails too, throw with a clear message:
+ * continuing with a half-wiped settings dir produces nondeterministic state
+ * that is far harder to debug than a failed startup.
+ */
+export async function removeDirWithRetry(dir: string): Promise<void> {
+	try {
+		fs.removeSync(dir);
+		return;
+	} catch (e: unknown) {
+		const code = (e as NodeJS.ErrnoException).code;
+		if (code !== 'EBUSY' && code !== 'EPERM') {
+			throw e;
+		}
+	}
+	await new Promise((resolve) => setTimeout(resolve, 500));
+	try {
+		fs.removeSync(dir);
+	} catch (e: unknown) {
+		throw new Error(
+			`Could not clean the settings directory ${dir} (${(e as NodeJS.ErrnoException).code}). ` +
+				`A process from a previous run may still be holding files there — close any leftover VS Code/ChromeDriver processes and retry.`,
+		);
+	}
+}
+
+/**
+ * Framework-injected user settings for the tested VS Code instance.
+ * Custom settings from --code_settings are merged ON TOP of these.
+ *
+ * INVARIANT: every value here must stay scalar. VS Code replaces
+ * object-valued settings whole at each scope, so the shallow spread in
+ * VSBrowser.start() is only faithful while no default is an object or
+ * array — a unit test guards this.
+ *
+ * @param codeVersion literal VS Code version being launched (gates
+ * settings that only exist in newer versions)
+ */
+export function getDefaultSettings(codeVersion: string): Record<string, string | boolean> {
+	return {
+		// Never let the tested VS Code instance update itself mid-run: on macOS
+		// the background updater replaces application files while tests execute,
+		// which manifests as "Your Code installation appears to be corrupt" and a
+		// dead extension host ("version mismatch") partway through a session.
+		'update.mode': 'none',
+		'update.showReleaseNotes': false,
+		// current enum form — the deprecated boolean `false` triggers a VS Code
+		// settings migration that rewrites settings.json shortly after launch
+		'extensions.autoUpdate': 'off',
+		'extensions.autoCheckUpdates': false,
+		'workbench.editor.enablePreview': false,
+		'workbench.startupEditor': 'none',
+		'window.titleBarStyle': 'custom',
+		'window.commandCenter': false,
+		'window.dialogStyle': 'custom',
+		'window.restoreFullscreen': true,
+		'window.newWindowDimensions': 'maximized',
+		'security.workspace.trust.enabled': false,
+		'files.simpleDialog.enable': true,
+		'terminal.integrated.copyOnSelection': true,
+		'workbench.secondarySideBar.defaultVisibility': 'hidden',
+		'workbench.welcomePage.experimentalOnboarding': false,
+		'workbench.welcomePage.walkthroughs.openOnInstall': false,
+		'workbench.editor.useModal': 'off',
+		// Disable workbench animations: VS Code >=1.133 fades the quick input
+		// out over 0.15s on close, so an isDisplayed() check right after
+		// accepting a pick still sees the widget. Whether motion is on depends
+		// on the OS reduced-motion preference (GitHub windows/macos runners
+		// report it, Xvfb linux does not), making runs environment-dependent.
+		'workbench.reduceMotion': 'on',
+		...(satisfies(codeVersion, '>=1.101.0') ? { 'window.menuStyle': 'custom' } : {}),
+	};
 }
 
 /**
@@ -468,10 +610,11 @@ export class CodeUtil {
 	 * @param cleanup remove the extension's directory as well.
 	 */
 	uninstallExtension(cleanup?: boolean): void {
-		const pjson = require(path.resolve('package.json'));
-		const extension = `${pjson.publisher}.${pjson.name}`;
-
 		if (cleanup) {
+			// resolved only when actually uninstalling — the no-op path must work
+			// from a directory without a package.json (e.g. plain test runs)
+			const pjson = require(path.resolve('package.json'));
+			const extension = `${pjson.publisher}.${pjson.name}`;
 			let command = `${this.getCliInitCommand()} --uninstall-extension "${extension}"`;
 			if (this.extensionsFolder) {
 				command += ` --extensions-dir="${this.extensionsFolder}"`;
@@ -522,6 +665,7 @@ export class CodeUtil {
 			this.parseSettings(runOptions.settings ?? DEFAULT_RUN_OPTIONS.settings),
 			runOptions.cleanup,
 			runOptions.locale,
+			{ keybindings: runOptions.keybindings, snippets: runOptions.snippets },
 		);
 		try {
 			return await runner.runTests(testFilesPattern, this, runOptions.resources, runOptions.logLevel);


### PR DESCRIPTION
## What

Final round of the `--code_settings` propagation hardening (follow-up to #2483 and #2484), covering the settings directory lifecycle:

- **Keybindings & snippets seeding** — the settings dir is wiped on every start for determinism, which also destroyed any pre-seeded user files and left no supported way to provide them. New `--code_keybindings <keybindings.json>` validates the file as a JSONC *array* (VS Code's own keybindings format; comments are preserved by copying verbatim) and seeds it into the test instance; `--code_snippets <folder>` copies a folder of snippet files (`<language>.json` / `*.code-snippets`) into `User/snippets`. Both available on `run-tests` and `setup-and-run`, with `run.keybindings` / `run.snippets` config keys, schema entries, and relative path resolution.
- **Resilient wipe** — an `EBUSY`/`EPERM` during the settings-dir removal previously logged a warning and continued with a half-wiped dir: nondeterministic leftover state that is far harder to debug than a failed startup. `removeDirWithRetry()` retries once after a short delay, then fails loudly naming the likely cause (a leftover process from a previous run).
- **Merge invariant guard** — the injected defaults moved into an exported `getDefaultSettings(codeVersion)`. VS Code replaces object-valued settings whole at each scope, so the shallow custom-settings spread is only faithful while every default stays scalar — a unit test now enforces that invariant, alongside tests pinning the merge semantics and the `window.menuStyle` version gate.
- **`extensions.autoUpdate: "off"`** — the deprecated boolean form triggered VS Code's settings migration, which rewrote the injected settings.json shortly after launch (observed live). The current enum form avoids the rewrite; pinned by test.
- **`uninstallExtension` fix** — it resolved `package.json` from the cwd *before* checking whether there was anything to clean up, throwing `MODULE_NOT_FOUND` in the mocha `afterAll` hook on every run outside an extension project. The require now lives inside the cleanup branch.

## Testing

- 15 new unit tests written test-first (TDD): `removeDirWithRetry` (3, incl. EBUSY-retry and EBUSY-persists via fs-extra stubs), `seedKeybindingsFile` (4, incl. verbatim JSONC copy and non-array root rejection), `seedSnippetsDir` (3), `getDefaultSettings` (4: scalar invariant, autoUpdate enum, version gate, merge semantics), `uninstallExtension` no-op path (1), plus `run.keybindings`/`run.snippets` path resolution in the config loader. Full `test:unit` suite: 122 passing. Repo-wide `prettier --check` clean.
- Verified live on VS Code 1.135.0 via the real CLI: seeded `keybindings.json` lands with comments intact, snippets are copied into `User/snippets`, custom settings remain honored alongside the seeded files, and the seeded `ctrl+alt+t` binding functionally opens the integrated terminal in the running instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)