### PR TITLE
fix(extester): suppress DEP0169 url.parse() warning from VS Code CLI

### DIFF
--- a/packages/extester/src/test/codeUtil.test.ts
+++ b/packages/extester/src/test/codeUtil.test.ts
@@ -183,7 +183,6 @@ describe('getDefaultSettings', () => {
 describe('removeDirWithRetry', () => {
 	// stub via the underlying CJS module object — the TS namespace import wrapper
 	// exposes re-exports through getters and cannot be assigned to
-	// eslint-disable-next-line @typescript-eslint/no-require-imports
 	const fsModule = require('fs-extra') as { removeSync: (dir: string) => void };
 	let dir: string;
 	const originalRemoveSync = fsModule.removeSync;

--- a/packages/extester/src/util/codeUtil.ts
+++ b/packages/extester/src/util/codeUtil.ts
@@ -533,7 +533,11 @@ export class CodeUtil {
 	}
 
 	private getCliInitCommand(): string {
-		return `${this.cliEnv} "${this.getExecutablePath()}" "${this.getCliPath()}"`;
+		// --no-deprecation: VS Code's own cliProcessMain.js still calls url.parse(), which Node 22+
+		// (bundled since VS Code ~1.100) reports as DEP0169 on stderr during --install-extension.
+		// Cannot use the targeted --disable-warning=DEP0169 flag: it requires Node >= 20.11,
+		// but the minimum supported VS Code (1.90) ships Node 20.9.
+		return `${this.cliEnv} "${this.getExecutablePath()}" --no-deprecation "${this.getCliPath()}"`;
 	}
 
 	private installExt(pathOrID: string, preRelease?: boolean): void {


### PR DESCRIPTION
## What

Silences the `DEP0169` `url.parse()` DeprecationWarning that leaks into test output right after `--install-extension`:

```
(node:3038) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.
(Use `code --trace-deprecation ...` to show where the warning was created)
```

## Root cause

The warning does not come from ExTester — the emitting process is VS Code's own CLI (note the hint says `code --trace-deprecation`, i.e. the VS Code binary). Reproduced with `--trace-deprecation` against VS Code 1.135:

```
at urlParse (node:url:136:13)
at ... vs/code/node/cliProcessMain.js ...
at async Qi.queryRawGalleryExtensions
at async Ds.updateMetadata
```

After a vsix install, VS Code's extension management queries the Marketplace gallery to update metadata, and its request service still calls `url.parse()`. DEP0169 became a **runtime** warning in Node 22 for non-`node_modules` code, and current VS Code builds bundle Electron with Node 22 — that's why the warning newly appears with recent VS Code versions. ExTester merely surfaces the child's stderr via `stdio: 'inherit'`.

## Fix

Add `--no-deprecation` to the CLI invocation built by `getCliInitCommand()`. The CLI runs via `ELECTRON_RUN_AS_NODE=1`, so the binary accepts plain Node flags on all platforms. This silences only the spawned VS Code CLI child (install/uninstall/open) — not ExTester itself, nor the VS Code instance under test.

The surgical `--disable-warning=DEP0169` flag was rejected deliberately: it requires Node >= 20.11, while the minimum supported VS Code (1.90) ships Node 20.9, where an unknown flag makes the process exit with an error.

## Verification

- Reproduced the warning with the exact command shape ExTester generates, then confirmed `--no-deprecation` in the generated position suppresses it and the vsix install still succeeds (exit 0), on VS Code 1.135/macOS.
- `npm run build --workspace=vscode-extension-tester` passes; all 122 unit tests pass (`npm run test:unit`).
- Windows covered: `findWindowsCliPath()` also returns a `cli.js` executed in run-as-node mode, so the flag placement is valid there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)