### PR TITLE
feat: harden clicks against hover/tooltip overlay interception

### DIFF
--- a/docs/Test-Setup.md
+++ b/docs/Test-Setup.md
@@ -188,18 +188,20 @@ The file passed via `-o`/`--code_settings` (or `run.settings` in the config file
 
 Before launch, ExTester merges your settings **on top of** its own framework defaults and writes the result to `<storage>/settings/User/settings.json` (user scope). Your values win on every key. These are the injected defaults:
 
-| Setting                                          | Value        | Why the framework sets it                                            |
-| ------------------------------------------------ | ------------ | -------------------------------------------------------------------- |
-| `update.mode` / `update.showReleaseNotes`        | `none` / off | A mid-run self-update corrupts the instance under test               |
-| `extensions.autoUpdate` / `autoCheckUpdates`     | off          | Same — extension state must not change mid-run                       |
-| `window.titleBarStyle` / `window.menuStyle`      | `custom`     | TitleBar/menu page objects only work with the custom title bar       |
-| `window.dialogStyle`                             | `custom`     | ModalDialog page objects (incl. the dirty-editor discard) need it    |
-| `workbench.reduceMotion`                         | `on`         | Disables UI animations that make element waits environment-dependent |
-| `files.simpleDialog.enable`                      | `true`       | Open/save dialog page objects need the simple (in-window) dialog     |
-| `security.workspace.trust.enabled`               | `false`      | Trust prompts would block the first window                           |
-| `workbench.editor.enablePreview`                 | `false`      | Editor tests assume real tabs, not preview tabs                      |
-| `workbench.startupEditor` + welcome/walkthroughs | none/off     | A deterministic empty workbench at startup                           |
-| `window.commandCenter`                           | `false`      | Keeps the title bar layout the page objects expect                   |
+| Setting                                          | Value        | Why the framework sets it                                                                                                                                |
+| ------------------------------------------------ | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `update.mode` / `update.showReleaseNotes`        | `none` / off | A mid-run self-update corrupts the instance under test                                                                                                   |
+| `extensions.autoUpdate` / `autoCheckUpdates`     | off          | Same — extension state must not change mid-run                                                                                                           |
+| `window.titleBarStyle` / `window.menuStyle`      | `custom`     | TitleBar/menu page objects only work with the custom title bar                                                                                           |
+| `window.dialogStyle`                             | `custom`     | ModalDialog page objects (incl. the dirty-editor discard) need it                                                                                        |
+| `workbench.reduceMotion`                         | `on`         | Disables UI animations that make element waits environment-dependent                                                                                     |
+| `workbench.hover.delay`                          | 7 days       | Workbench tooltips are DOM overlays that appear while the WebDriver pointer rests on the last click point, never auto-hide, and intercept the next click |
+| `editor.stickyScroll.enabled`                    | `false`      | The sticky-scroll overlay eats clicks aimed at the top editor lines                                                                                      |
+| `files.simpleDialog.enable`                      | `true`       | Open/save dialog page objects need the simple (in-window) dialog                                                                                         |
+| `security.workspace.trust.enabled`               | `false`      | Trust prompts would block the first window                                                                                                               |
+| `workbench.editor.enablePreview`                 | `false`      | Editor tests assume real tabs, not preview tabs                                                                                                          |
+| `workbench.startupEditor` + welcome/walkthroughs | none/off     | A deterministic empty workbench at startup                                                                                                               |
+| `window.commandCenter`                           | `false`      | Keeps the title bar layout the page objects expect                                                                                                       |
 
 Overriding one of these is allowed but prints a warning with the old → new values, since several of them are load-bearing for the page objects.
 

--- a/packages/extester/src/test/codeUtil.test.ts
+++ b/packages/extester/src/test/codeUtil.test.ts
@@ -174,6 +174,14 @@ describe('getDefaultSettings', () => {
 		assert.strictEqual(getDefaultSettings('1.101.0')['window.menuStyle'], 'custom');
 	});
 
+	it('pushes workbench hovers out of reach so they cannot intercept clicks', () => {
+		assert.strictEqual(getDefaultSettings('1.135.0')['workbench.hover.delay'], 604_800_000);
+	});
+
+	it('disables editor sticky scroll so its overlay cannot intercept clicks on top editor lines', () => {
+		assert.strictEqual(getDefaultSettings('1.135.0')['editor.stickyScroll.enabled'], false);
+	});
+
 	it('replaces object-valued custom settings whole in the merge, like VS Code scopes do', () => {
 		const merged = { ...getDefaultSettings('1.135.0'), ...{ 'files.exclude': { '**/out': true } } };
 		assert.deepStrictEqual(merged['files.exclude'], { '**/out': true });

--- a/packages/extester/src/util/codeUtil.ts
+++ b/packages/extester/src/util/codeUtil.ts
@@ -168,7 +168,7 @@ export async function removeDirWithRetry(dir: string): Promise<void> {
  * @param codeVersion literal VS Code version being launched (gates
  * settings that only exist in newer versions)
  */
-export function getDefaultSettings(codeVersion: string): Record<string, string | boolean> {
+export function getDefaultSettings(codeVersion: string): Record<string, string | boolean | number> {
 	return {
 		// Never let the tested VS Code instance update itself mid-run: on macOS
 		// the background updater replaces application files while tests execute,
@@ -200,6 +200,17 @@ export function getDefaultSettings(codeVersion: string): Record<string, string |
 		// on the OS reduced-motion preference (GitHub windows/macos runners
 		// report it, Xvfb linux does not), making runs environment-dependent.
 		'workbench.reduceMotion': 'on',
+		// Workbench chrome hovers (tab/tree-row/action-bar/status-bar tooltips)
+		// are DOM overlays that appear while the WebDriver pointer rests on the
+		// last click point and never auto-hide, deadlocking the next click's
+		// pre-dispatch hit-test (ElementClickInterceptedError). There is no
+		// off-switch upstream, but the delay has no maximum — push it out of
+		// reach (7 days). Editor content hovers stay untouched: extension
+		// authors legitimately test their HoverProviders.
+		'workbench.hover.delay': 604_800_000,
+		// Same hazard class: sticky scroll is a permanent overlay that eats
+		// clicks aimed at the top editor lines once the editor is scrolled.
+		'editor.stickyScroll.enabled': false,
 		...(satisfies(codeVersion, '>=1.101.0') ? { 'window.menuStyle': 'custom' } : {}),
 	};
 }

--- a/packages/page-objects/src/components/AbstractElement.ts
+++ b/packages/page-objects/src/components/AbstractElement.ts
@@ -91,6 +91,17 @@ export abstract class AbstractElement extends WebElement {
 		return (await super.isEnabled()) && (await AbstractElement.locators.AbstractElement.enabled(this));
 	}
 
+	/**
+	 * Click the element, recovering when a transient overlay intercepts the
+	 * click. VS Code renders hovers/tooltips as DOM overlays that appear while
+	 * the WebDriver pointer rests on the last click point and never auto-hide,
+	 * so a plain W3C click deadlocks on its pre-dispatch hit-test. See
+	 * {@link WaitHelper.clickThroughInterception} for the recovery strategy.
+	 */
+	async click(): Promise<void> {
+		await AbstractElement.waitHelper.clickThroughInterception(this, () => super.click());
+	}
+
 	async isSelected(): Promise<boolean> {
 		return (await super.isSelected()) && (await AbstractElement.locators.AbstractElement.selected(this));
 	}

--- a/packages/page-objects/src/components/editor/EditorView.ts
+++ b/packages/page-objects/src/components/editor/EditorView.ts
@@ -274,28 +274,9 @@ export class EditorGroup extends AbstractElement {
 	async closeEditor(title: string): Promise<void> {
 		const tab = await this.getTabByTitle(title);
 		const closeButton = await tab.findElement(EditorView.locators.EditorView.closeTab);
-		// VS Code renders hover tooltip overlays (<div class="hover-contents">) that can
-		// intercept the click (ElementClickInterceptedError) on CI. Retry with an
-		// increasing delay; fall back to a JS-executor click on the last attempt which
-		// bypasses overlay elements entirely.
-		const maxAttempts = 3;
-		for (let attempt = 0; attempt < maxAttempts; attempt++) {
-			try {
-				await closeButton.click();
-				return;
-			} catch (err: any) {
-				if (err.name !== 'ElementClickInterceptedError' || attempt === maxAttempts - 1) {
-					// On the final attempt use executeScript to bypass the overlay, then return.
-					if (err.name === 'ElementClickInterceptedError') {
-						await this.getDriver().executeScript('arguments[0].click()', closeButton);
-						return;
-					}
-					throw err;
-				}
-				// Brief back-off so the tooltip has time to dismiss before the next attempt.
-				await this.getWaitHelper().sleep(300 * (attempt + 1));
-			}
-		}
+		// hover tooltip overlays can intercept the click on CI - the centralized
+		// recovery parks the pointer to dismiss them and retries the native click
+		await this.getWaitHelper().clickThroughInterception(closeButton);
 	}
 
 	/**

--- a/packages/page-objects/src/utils/WaitHelper.ts
+++ b/packages/page-objects/src/utils/WaitHelper.ts
@@ -558,6 +558,85 @@ export class WaitHelper {
 	}
 
 	/**
+	 * Move the virtual pointer to a quiet spot: the title-bar drag region at the
+	 * top-center of the window (the command center is disabled by the framework's
+	 * default settings, and unlike the status bar the area has no hover targets).
+	 *
+	 * A WebDriver session has no OS mouse - the pointer rests wherever the last
+	 * interaction left it. VS Code hovers appear while the pointer rests on an
+	 * element and are torn down only when it moves away, so parking delivers the
+	 * mouseout an open hover is waiting for and disarms pending hover timers.
+	 */
+	async parkPointer(): Promise<void> {
+		const width = Number(await this.driver.executeScript('return window.innerWidth')) || 200;
+		await this.driver
+			.actions()
+			.move({ x: Math.floor(width / 2), y: 5 })
+			.perform();
+	}
+
+	/**
+	 * Click an element, recovering when a transient overlay intercepts the click.
+	 *
+	 * VS Code renders rich hovers/tooltips as DOM overlays that appear while the
+	 * pointer rests on the last click point and never auto-hide. A W3C click
+	 * hit-tests the click point BEFORE dispatching any event, so a resting hover
+	 * over the target fails every attempt until the pointer actually moves -
+	 * waiting alone can never resolve it. On interception this actively parks
+	 * the pointer (dismissing pointer-rest overlays), waits for hover teardown
+	 * and retries the native click. As a last resort it falls back to a
+	 * JS-executor click, which bypasses hit-testing but also mousedown semantics
+	 * (Monaco lists select on mousedown) - the fallback is logged so the call
+	 * site's true blocker can be root-caused instead of silently papered over.
+	 *
+	 * @param element the element to click
+	 * @param nativeClick override for the native click action (used by
+	 * AbstractElement.click() to reach WebElement.prototype.click through its
+	 * own override)
+	 */
+	async clickThroughInterception(element: WebElement, nativeClick: () => Promise<void> = () => element.click()): Promise<void> {
+		const maxNativeAttempts = 3;
+		for (let attempt = 0; ; attempt++) {
+			try {
+				return await nativeClick();
+			} catch (e) {
+				if ((e as Error).name !== 'ElementClickInterceptedError') {
+					throw e;
+				}
+				// a modal dialog blocks the whole workbench by design - neither
+				// pointer parking nor a JS click may subvert it: JS-clicking
+				// through the blocker would trigger actions the real UI forbids.
+				// Fail fast with the original error so modal-aware callers (and
+				// test authors) see the true blocker.
+				const modalUp = await this.driver
+					.executeScript(
+						'return Array.from(document.querySelectorAll(".monaco-dialog-modal-block, .monaco-dialog-box")).some((el) => el.checkVisibility());',
+					)
+					.catch(() => false);
+				if (modalUp) {
+					throw e;
+				}
+				if (attempt >= maxNativeAttempts - 1) {
+					console.warn(
+						`clickThroughInterception: falling back to a JS click after ${maxNativeAttempts} intercepted attempts: ${(e as Error).message}`,
+					);
+					await this.driver.executeScript('arguments[0].click();', element);
+					return;
+				}
+				await this.parkPointer();
+				// hover teardown is event-driven and near-instant once the pointer
+				// moved away; a non-hover interceptor (modal, toast) never passes
+				// this check, so time-box it and retry regardless
+				await this.forCondition(
+					async () =>
+						await this.driver.executeScript('return !Array.from(document.querySelectorAll(".monaco-hover")).some((el) => el.checkVisibility());'),
+					{ timeout: 1500, pollInterval: 50, message: 'hover overlay did not dismiss after parking the pointer' },
+				).catch(() => undefined);
+			}
+		}
+	}
+
+	/**
 	 * Get the WebDriver instance.
 	 */
 	getDriver(): WebDriver {

--- a/tests/test-project/src/test/01_general/clickInterception.test.ts
+++ b/tests/test-project/src/test/01_general/clickInterception.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License", destination); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from 'chai';
+import * as path from 'path';
+import { EditorView, VSBrowser } from 'vscode-extension-tester';
+import { waitFor } from '../testUtils';
+
+const FILE_A = 'test-file-a.txt';
+const FILE_B = 'test-file-b.txt';
+
+/**
+ * Synthetic stand-in for a VS Code hover widget: a DOM overlay covering the
+ * click target. VS Code hovers appear while the WebDriver pointer rests on the
+ * last click point and are torn down only when the pointer moves away — the
+ * "dismissing" variant reproduces exactly that contract (removes itself on the
+ * first real mousemove), while the "persistent" variant models overlays no
+ * pointer movement can dismiss (modals, toasts).
+ */
+const INJECT_OVERLAY = `
+	const [target, dismissOnMouseMove, overlayClass] = arguments;
+	const rect = target.getBoundingClientRect();
+	const overlay = document.createElement('div');
+	overlay.className = (overlayClass || 'monaco-hover') + ' extester-probe-overlay';
+	overlay.style.cssText = 'position:fixed;z-index:100000;pointer-events:auto;'
+		+ 'left:' + (rect.left - 10) + 'px;top:' + (rect.top - 10) + 'px;'
+		+ 'width:' + (rect.width + 20) + 'px;height:' + (rect.height + 20) + 'px;';
+	document.body.appendChild(overlay);
+	if (dismissOnMouseMove) {
+		const onMove = () => {
+			overlay.remove();
+			document.removeEventListener('mousemove', onMove, true);
+		};
+		document.addEventListener('mousemove', onMove, true);
+	}
+`;
+
+const REMOVE_OVERLAYS = `document.querySelectorAll('.extester-probe-overlay').forEach((el) => el.remove());`;
+
+describe('Click interception recovery', function () {
+	this.timeout(60000);
+	let editorView: EditorView;
+
+	before(async function () {
+		this.timeout(120000);
+		await VSBrowser.instance.openResources(
+			path.resolve(__dirname, '..', '..', '..', 'resources', FILE_A),
+			path.resolve(__dirname, '..', '..', '..', 'resources', FILE_B),
+		);
+		editorView = new EditorView();
+		await waitFor(
+			async () => {
+				const titles = await editorView.getOpenEditorTitles();
+				return titles.includes(FILE_A) && titles.includes(FILE_B);
+			},
+			{ timeout: 15000, message: `Resources ${FILE_A} or ${FILE_B} did not open` },
+		);
+	});
+
+	afterEach(async function () {
+		await VSBrowser.instance.driver.executeScript(REMOVE_OVERLAYS);
+	});
+
+	after(async function () {
+		await new EditorView().closeAllEditors();
+	});
+
+	it('clicks through a hover-like overlay that dismisses on pointer movement', async function () {
+		// make FILE_A the active tab with a plain, unobstructed click
+		await (await editorView.getTabByTitle(FILE_A)).click();
+		const tabB = await editorView.getTabByTitle(FILE_B);
+		await VSBrowser.instance.driver.executeScript(INJECT_OVERLAY, tabB, true);
+
+		await tabB.click();
+
+		// Tabs switch on mousedown, which a JS-executor click cannot produce: a
+		// passing assertion proves a REAL click landed after the overlay was
+		// dismissed by actual pointer movement.
+		const active = await editorView.getActiveTab();
+		expect(await active?.getTitle()).equals(FILE_B);
+	});
+
+	it('does not throw when the intercepting overlay never dismisses', async function () {
+		const tabA = await editorView.getTabByTitle(FILE_A);
+		await VSBrowser.instance.driver.executeScript(INJECT_OVERLAY, tabA, false);
+
+		// the persistent overlay swallows every native attempt — the click must
+		// still resolve (JS-executor fallback) instead of throwing
+		await tabA.click();
+	});
+
+	it('rethrows when a modal blocker intercepts instead of JS-clicking through it', async function () {
+		const tabA = await editorView.getTabByTitle(FILE_A);
+		await VSBrowser.instance.driver.executeScript(INJECT_OVERLAY, tabA, false, 'monaco-dialog-modal-block');
+
+		// a modal-blocked UI must fail fast with the original error — a
+		// JS-executor click through a modal would trigger actions the real UI
+		// forbids and leave the workbench in an inconsistent state
+		let thrown: Error | undefined;
+		try {
+			await tabA.click();
+		} catch (e) {
+			thrown = e as Error;
+		}
+		expect(thrown?.name).equals('ElementClickInterceptedError');
+	});
+});


### PR DESCRIPTION
## Problem

`ElementClickInterceptedError` (and "the click silently did nothing") failures keep increasing across UI test runs, caused by VS Code hovers/tooltips overlaying click targets. This is not ordinary timing flakiness — it is a deadlock between two correct behaviors:

- A WebDriver session has no OS mouse: every click dispatches events at the target's center and the virtual pointer then **rests there indefinitely**. VS Code's hover service arms a timer on `mouseover` and needs no further events, so **every click plants a delayed hover** (`.monaco-hover` DOM overlay, 300–1500 ms later) at the clicked location. These overlays **never auto-hide** — they are torn down only when the pointer moves away.
- Per the W3C spec, ChromeDriver **hit-tests the click point before dispatching any event**. A resting hover over the next target fails that check — and the one event that would dismiss the hover (the mousemove toward the target) is exactly what ChromeDriver refuses to send. Sleep-and-retry can never converge; the existing back-off workaround in `closeEditor` always ended at its JS-click fallback for this reason.

The surface grows with every VS Code release as more native `title` tooltips (OS-drawn, cannot intercept) are migrated to custom DOM hovers — which is why these failures keep getting more frequent.

## Fix (layered)

1. **Settings (root-cause removal)** — `workbench.hover.delay: 604800000` in the injected defaults: workbench chrome hovers (tabs, tree rows, action bars, status bar) have no off-switch upstream, but the delay has no maximum. Also `editor.stickyScroll.enabled: false` (same hazard class: a permanent overlay eating clicks on top editor lines). Editor content hovers stay untouched so extension authors can still test their `HoverProvider`s. No framework API reads rendered hovers (all `getTooltip()` implementations read `title`/`aria-label`/`data-tooltip` attributes), and `--code_settings` can override both defaults (documented in Test-Setup.md).
2. **`WaitHelper.parkPointer()`** — moves the virtual pointer to the empty title-bar drag region, delivering the mouseout an open hover is waiting for and disarming pending hover timers. The only true dismissal mechanism.
3. **`AbstractElement.click()` override → `WaitHelper.clickThroughInterception()`** — Playwright-style actionability loop: on interception, park the pointer, wait for hover teardown, retry the native click (×3). A JS-executor click is the *logged* last resort (it bypasses `mousedown`, which Monaco lists rely on), and it is **refused while a modal dialog blocks the workbench** so tests cannot punch through dialogs. Every page object and downstream page-object click inherits this with zero call-site churn; raw `findElement()` elements can call the helper directly — `EditorGroup.closeEditor` now does, replacing its local workaround.

## Tests

- Two unit tests for the new defaults (`getDefaultSettings`).
- A deterministic UI probe (`01_general/clickInterception.test.ts`) reproducing the deadlock with a synthetic overlay that mirrors real hover semantics (dismissed only by actual pointer movement). It covers: recovery via a **real** retried click (asserts the tab actually switched — a JS fallback cannot switch tabs, since tabs react to `mousedown`), the JS-click fallback for overlays nothing dismisses, and the fail-fast path under a modal blocker. All three were watched fail for the expected reason before the implementation existed.

## Verification

- extester unit tests: 124 passing.
- Probe suite: 3/3 on VS Code 1.135.0.
- Editor group (heaviest `closeEditor`/click user) run locally: 93 passing; the two observed failures were proven pre-existing environment flake — they reproduce identically on an upstream-baseline build on the same machine and pass with this branch when re-run (alone and paired, twice).

Follow-up (out of scope here): pointer hygiene for coordinate-based Actions clicks (e.g. `EditorTab.select`), which bypass hit-testing entirely and can still be swallowed silently by an open overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
