### PR TITLE
docs(extester-runner): fix stale setting IDs and remove nonexistent suite-run claim

### DIFF
--- a/docs-site/src/content/docs/guides/extester-runner.md
+++ b/docs-site/src/content/docs/guides/extester-runner.md
@@ -9,7 +9,7 @@ title: ExTester Runner
 1. Install the ExTester Runner extension from the VS Code marketplace
 2. Open your VS Code extension project
 3. Click the ExTester Runner icon in the Activity Bar
-4. Find your test in the Test Explorer
+4. Find your test in the UI Tests view
 5. Click the play button (▶️) to run it
 
 ## What is ExTester Runner?

--- a/packages/extester-runner/README.md
+++ b/packages/extester-runner/README.md
@@ -39,14 +39,14 @@ The extension makes running tests incredibly simple and efficient:
 
 1. Open your VS Code extension project
 2. Click the ExTester Runner icon in the Activity Bar
-3. Find your test in the Test Explorer
+3. Find your test in the UI Tests view
 4. Click the play button (▶️) to run it
 
 #### Running Tests
 
-- **Test Suite**: Click the play button next to a `describe()` block to run all tests in that suite
 - **Test File**: Click the play button next to a test file to run all tests in that file
-- **All Tests**: Click the play button at the top of the Test Explorer to run everything
+- **Test Folder**: Click the play button next to a folder to run all test files inside it
+- **All Tests**: Click the play button at the top of the UI Tests view to run everything
 
 ### Test Management
 
@@ -59,7 +59,7 @@ The extension makes running tests incredibly simple and efficient:
 
 ### Automatic Updates
 
-- Test Explorer automatically refreshes when:
+- UI Tests view automatically refreshes when:
   - Test files are added, removed or modified
   - Test configurations change
 - Screenshots view updates when:
@@ -71,15 +71,18 @@ The extension makes running tests incredibly simple and efficient:
 
 ### Configuration Options
 
+All settings live under the `extesterRunner` namespace:
+
 - `testFileGlob`: Glob pattern for test files
 - `excludeGlob`: Glob pattern for excluded paths
 - `ignorePathPart`: Path segment to remove from folder labels
 - `additionalArgs`: Additional CLI arguments for test runner
-- `outFolder`: Path to compiled output directory
+- `outputFolder`: Path to compiled output directory
 - `rootFolder`: Path to test source root
 - `tempFolder`: Directory for test artifacts
-- `vsCodeVersion`: VS Code version for test execution
-- `vsCodeType`: VS Code build type (e.g., "Insiders" or "Stable")
+- `visualStudioCode.Version`: VS Code version for test execution (`max`, `min`, `latest`, or a specific version)
+- `visualStudioCode.Type`: VS Code build type (`stable` or `insider`)
+- `hideEmptyLogFolders`: Hide empty log directories in the Logs view
 
 ## Logging
 

--- a/packages/extester-runner/features_list.md
+++ b/packages/extester-runner/features_list.md
@@ -55,22 +55,23 @@ The extension contributes several settings under the namespace extesterRunner:
 - `testFileGlob` (string): Glob pattern to find test files (default `**/ui-test/**/*.test.ts`).
 - `excludeGlob` (string): Glob pattern of paths to exclude from test search (default `**/node_modules/**`).
 - `ignorePathPart` (string): If set, any matching path segment is removed from folder labels in the UI Tests view (for cleaner display, e.g., remove common prefix paths).
-- `additionalArgs` (string): Additional CLI arguments to pass to the test runner (`extest`) when executing tests (e.g., user-defined options).
-- `outFolder` (string): Path to the compiled output directory for tests.
+- `additionalArgs` (array of strings): Additional CLI arguments to pass to the test runner (`extest`) when executing tests (e.g., user-defined options).
+- `outputFolder` (string): Path to the compiled output directory for tests (default `out`).
 - `rootFolder` (string): Path to the test source root.
 - `tempFolder` (string): Directory for test artifacts (logs, screenshots). If empty, the extension uses a default temp directory or an environment variable `TEST_RESOURCES`.
-- `vsCodeVersion` (string): Which VS Code version to use for running tests (passed to the test runner CLI as `--code_version`, e.g., `"1.70.0"`).
-- `vsCodeType` (string): Which VS Code build to use for tests (e.g., `"Insiders"` or `"Stable"`, passed as `--code_type`).
+- `visualStudioCode.Version` (string): Which VS Code version to use for running tests (passed to the test runner CLI as `--code_version`; `max`, `min`, `latest`, or a specific version like `"1.97.1"`; default `max`).
+- `visualStudioCode.Type` (string): Which VS Code build to use for tests (`stable` or `insider`, passed as `--code_type`; default `stable`).
+- `hideEmptyLogFolders` (boolean): When enabled (default), only log folders containing files are shown in the Logs view.
 
 Changing any extesterRunner setting triggers a refresh of the test, logs, and screenshots views (the extension listens to configuration changes and refreshes accordingly).
 
 # Tasks / Test Runner Integration:
 
-The extension does not directly define new task types in `package.json`, but internally it uses the VS Code Task API to run tests via the `vscode-extension-teste` CLI (`extest`). Specifically:
+The extension defines an `extester-runner-task` task type in `package.json` and uses the VS Code Task API to run tests via the `vscode-extension-tester` CLI (`extest`). Specifically:
 
 - RunAllTestsTask (extends vscode.Task): Configured to run npx extest setup-and-run <outDir> [options] for all tests.
 - RunFolderTask: Similar, but runs tests only under a specific folder path.
-- RunFileTask: Runs tests from a single file. It calculates the output `.js` file path corresponding to the source `.ts` file (using `rootFolder/outFolder` settings and then runs `npx extest setup-and-run '<compiled-file-path>' [options]`.
+- RunFileTask: Runs tests from a single file. It calculates the output `.js` file path corresponding to the source `.ts` file (using `rootFolder`/`outputFolder` settings and then runs `npx extest setup-and-run '<compiled-file-path>' [options]`.
 - These tasks use `ShellExecution` to invoke the `extest` CLI and pass arguments based on the settings (e.g., `--storage <tempFolder>`for custom temp directory, `--code_version`, `--code_type`, and any extra `additionalArgs`). They ensure the task execution is awaited (using `vscode.tasks.executeTas` and listening for task completion) before allowing another run.
 
 # Logging:

--- a/packages/extester-runner/package.json
+++ b/packages/extester-runner/package.json
@@ -2,7 +2,7 @@
   "name": "extester-runner",
   "displayName": "ExTester Runner",
   "icon": "resources/logo.png",
-  "description": "Extension for vscode-extension-tester which allow users to run, debug, list tests directly inside VS Code.",
+  "description": "Extension for vscode-extension-tester which allows users to list and run UI tests directly inside VS Code.",
   "publisher": "redhat",
   "preview": true,
   "private": true,


### PR DESCRIPTION
## What

Aligns the marketplace-facing extester-runner docs with the extension's actual `contributes` section, which they had drifted from.

### README.md
- Setting IDs corrected: `outFolder` → `outputFolder`, `vsCodeVersion` → `visualStudioCode.Version`, `vsCodeType` → `visualStudioCode.Type`; the Type enum is `stable`/`insider`, not "Insiders"/"Stable"
- Removed the **Test Suite** play-button bullet — there is no per-`describe()` run command (only `runFile`, `runFolder`, `runAll`); replaced with the real folder-level entry
- Added the missing `hideEmptyLogFolders` setting and a note that all settings live under the `extesterRunner` namespace
- Renamed "Test Explorer" to the extension's actual **UI Tests** view (avoids implying integration with VS Code's built-in testing UI)

### features_list.md
Same setting-ID fixes, plus: `additionalArgs` is an array (not a string), and an `extester-runner-task` task type *is* defined in `package.json` (the file claimed none was).

### package.json
Description softened to "list and run UI tests" — the extension has no debug integration (verified: every `debug` hit in `src/` is the logger's `debug()` method or test fixtures). Also fixes the "which allow users" grammar slip.

### docs-site
The new Starlight guide (`guides/extester-runner.md`) was already written from the real contributes section; the only stale reference left was one "Test Explorer" mention in Quick Start, now "UI Tests view". A repo-wide sweep of `docs-site/` found nothing else.

## Verification

Every claim was checked against `packages/extester-runner/package.json` `contributes` before editing; `package.json` still parses as valid JSON. Docs-only change (plus the one-line description string), no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)