### PR TITLE
fix(extester): drop stray noCache from DEFAULT_RUN_OPTIONS

### DIFF
--- a/docs-site/src/content/docs/guides/test-setup.md
+++ b/docs-site/src/content/docs/guides/test-setup.md
@@ -391,6 +391,8 @@ The ExTester implements a caching mechanism for both VS Code and ChromeDriver do
 
 #### Using --no_cache
 
+Caching is a setup-phase concern: the `-n` / `--no_cache` flag is accepted by `get-vscode`, `get-chromedriver`, `setup-tests`, and `setup-and-run`, and maps to `setup.noCache` in the config file. The `run` section has no caching option — `run-tests` downloads nothing. In the API, the same switch is `SetupOptions.noCache` and the `noCache` parameter of `downloadCode()` / `downloadChromeDriver()`.
+
 When the `--no_cache` option is enabled:
 
 1. **Resource Behavior**:
@@ -483,12 +485,11 @@ export interface CustomPageObjectsOptions {
 }
 /** defaults for the RunOptions */
 export declare const DEFAULT_RUN_OPTIONS: {
-  vscodeVersion: "latest";
-  settings: "";
-  logLevel: logging.Level.INFO;
+  vscodeVersion: string;
+  settings: string;
+  logLevel: logging.Level;
   offline: false;
   resources: never[];
-  noCache: false;
 };
 
 /**

--- a/packages/extester/src/util/codeUtil.ts
+++ b/packages/extester/src/util/codeUtil.ts
@@ -319,8 +319,7 @@ export const DEFAULT_RUN_OPTIONS = {
 	logLevel: logging.Level.INFO,
 	offline: false,
 	resources: [],
-	noCache: false,
-};
+} satisfies RunOptions;
 
 /**
  * Handles the VS Code instance used for testing.


### PR DESCRIPTION
## What

`DEFAULT_RUN_OPTIONS` carried a `noCache: false` entry that no `RunOptions` consumer ever declared or read — it slipped in with the caching feature (#1888) while the real wiring went through `downloadVSCode(version, noCache)` and `SetupOptions`. This PR removes the dead entry and constrains the constant with `satisfies RunOptions`, so any future stray key in the defaults becomes a compile error (without widening the inferred property types that `CodeUtil.runTests` relies on).

## Why noCache does not belong in RunOptions

`noCache` is a setup-time switch (skip cached VS Code/ChromeDriver downloads):

- The CLI resolves `cmd.no_cache || setup.noCache` only for `get-vscode`, `get-chromedriver`, `setup-tests`, and `setup-and-run`; `run-tests` has no `-n` flag.
- The API declares it on `SetupOptions`, and `CodeUtil.runTests` never reads a `noCache` property — running tests downloads nothing.
- `extester.config.json` is already consistent: `noCache` exists only in the `setup` section, and the schema's `run` section rejects unknown keys.

## Docs

The docs-site test-setup guide is updated accordingly: the `DEFAULT_RUN_OPTIONS` declaration snippet now mirrors the actual emitted `.d.ts` (no `noCache`), and the caching section spells out which commands accept `-n`/`--no_cache` and that the switch lives in `setup.noCache` / `SetupOptions.noCache`.

## Verification

- Constraining the constant with `satisfies RunOptions` alone made `tsc` fail with `TS2353: 'noCache' does not exist in type 'RunOptions'`; removing the entry made it pass — the constraint demonstrably guards this.
- `npm run test:unit` in `packages/extester`: 124 passing.
- `npm run build` in `docs-site`: 58 pages built, all internal links valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)