### PR TITLE
ci: collect framework coverage in Main CI and run coverage.yml nightly

### DIFF
--- a/.github/c8-framework.json
+++ b/.github/c8-framework.json
@@ -1,0 +1,10 @@
+{
+  "all": true,
+  "src": "packages",
+  "include": ["packages/*/out/**"],
+  "exclude": ["packages/*/out/test/**", "packages/extester-runner/**"],
+  "extension": [".js"],
+  "exclude-after-remap": false,
+  "reporter": ["text", "text-summary", "html", "lcov"],
+  "reports-dir": "coverage/framework"
+}

--- a/.github/scripts/trim-v8-coverage.mjs
+++ b/.github/scripts/trim-v8-coverage.mjs
@@ -1,0 +1,59 @@
+/**
+ * Trims raw NODE_V8_COVERAGE dumps down to the scripts that live under
+ * <workspace>/packages/. Every Node process spawned during a UI test run
+ * (npm, the ExTester runner, the VS Code CLI, VS Code itself and its
+ * extension host) writes a dump that mostly describes Node builtins and
+ * VS Code internals; only the framework code is wanted in the report, and
+ * shipping the rest as CI artifacts is pure cost.
+ *
+ * Usage: node trim-v8-coverage.mjs <dump-dir> <workspace-dir>
+ */
+import { readdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const [dumpDir, workspaceDir] = process.argv.slice(2);
+if (!dumpDir || !workspaceDir) {
+	console.error('usage: trim-v8-coverage.mjs <dump-dir> <workspace-dir>');
+	process.exit(2);
+}
+
+// V8 records real paths, so resolve symlinks the same way before comparing.
+const prefix = `${pathToFileURL(realpathSync(resolve(workspaceDir))).href}/packages/`;
+let files = 0;
+let kept = 0;
+let bytesBefore = 0;
+let bytesAfter = 0;
+
+for (const name of readdirSync(dumpDir)) {
+	if (!name.endsWith('.json')) {
+		continue;
+	}
+	const file = join(dumpDir, name);
+	files++;
+	bytesBefore += statSync(file).size;
+	let dump;
+	try {
+		dump = JSON.parse(readFileSync(file, 'utf8'));
+	} catch {
+		// A process that died mid-write leaves a truncated file; c8 would skip it too.
+		rmSync(file);
+		continue;
+	}
+	const result = (dump.result ?? []).filter((script) => typeof script.url === 'string' && script.url.startsWith(prefix));
+	if (result.length === 0) {
+		rmSync(file);
+		continue;
+	}
+	const trimmed = { result };
+	if (dump['source-map-cache']) {
+		trimmed['source-map-cache'] = Object.fromEntries(Object.entries(dump['source-map-cache']).filter(([url]) => url.startsWith(prefix)));
+	}
+	const json = JSON.stringify(trimmed);
+	writeFileSync(file, json);
+	kept++;
+	bytesAfter += Buffer.byteLength(json);
+}
+
+const mb = (n) => (n / 1048576).toFixed(2);
+console.log(`trim-v8-coverage: kept ${kept} of ${files} dump files, ${mb(bytesBefore)} MB -> ${mb(bytesAfter)} MB (prefix ${prefix})`);

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,22 +1,18 @@
+# Nightly smoke run of the `extest --coverage` feature against the sample
+# extension in tests/test-project. It measures the sample extension, not the
+# framework: framework coverage is collected as a byproduct of the Main CI
+# matrix (see the `coverage` job in main.yml). This job is intentionally not
+# tied to pull requests - failing tests do not invalidate the numbers, but a
+# missing report does, so that is the only thing that fails the job.
 name: 📊 Code Coverage
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "**"
-      - "!docs-site/**"
-      - "!packages/extester-runner/**"
-  pull_request:
-    branches: [main]
-    paths:
-      - "**"
-      - "!docs-site/**"
-      - "!packages/extester-runner/**"
+  schedule:
+    - cron: "0 3 * * *"
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -50,11 +46,16 @@ jobs:
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
       - name: 📊 Run Tests with Coverage enabled
-        # 'set +e' and 'exit 0' - that means the workflow will not fail even the test failures are present. The failing tests are not directive for the code coverage reports itself
+        # Test failures are not a problem for the coverage report, so the run
+        # is allowed to fail; only a missing report fails the job.
         run: |
           set +e
           xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npm run test:coverage
-          exit 0
+          set -e
+          if [ ! -f tests/test-project/coverage/index.html ]; then
+            echo "::error::No coverage report was produced in tests/test-project/coverage"
+            exit 1
+          fi
 
       - name: 💾 Upload Coverage
         uses: actions/upload-artifact@v7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,6 +121,84 @@ jobs:
     with:
       test_group: xsideBar
 
+  coverage:
+    name: 📊 Framework Coverage
+    # Merges the V8 dumps that the ubuntu cells of every suite job collected
+    # while running the UI tests (see template-suite.yaml) into one report of
+    # how much of packages/* the UI tests exercise. Informational only: it is
+    # not part of the status check, and it runs even when suites failed.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    needs:
+      - group_01_general
+      - group_activityBar
+      - group_bottomBar
+      - group_cli
+      - group_debug
+      - group_dialog
+      - group_editor
+      - group_menu
+      - group_statusBar
+      - group_system
+      - group_webview
+      - group_workbench
+      - group_xsideBar
+    steps:
+      - name: 👷🏻 Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: ⚙️ Setup NodeJS
+        uses: actions/setup-node@v7
+        with:
+          node-version: "lts/*"
+          cache: npm
+
+      - name: 🔧 Install
+        run: npm ci --ignore-scripts
+
+      # The dumps reference packages/*/out/*.js by absolute path and the source
+      # maps next to them; the same build at the same path is needed to remap.
+      - name: 🔧 Build
+        run: npm run build
+
+      - name: 📥 Download V8 coverage dumps
+        uses: actions/download-artifact@v7
+        with:
+          pattern: v8-coverage-*
+          path: ${{ runner.temp }}/v8-downloads
+
+      - name: 🔀 Merge dumps into one directory
+        run: |
+          merged="${RUNNER_TEMP}/v8-merged"
+          mkdir -p "$merged"
+          for dir in "${RUNNER_TEMP}"/v8-downloads/*/; do
+            name=$(basename "$dir")
+            for file in "$dir"*.json; do
+              [ -e "$file" ] || continue
+              mv "$file" "$merged/${name}-$(basename "$file")"
+            done
+          done
+          echo "Merged $(ls "$merged" | wc -l) dump files"
+
+      - name: 📊 Generate framework coverage report
+        run: |
+          npx c8 report --config .github/c8-framework.json --temp-directory "${RUNNER_TEMP}/v8-merged" | tee "${RUNNER_TEMP}/coverage.txt"
+          {
+            echo "## Framework coverage (packages/*, ubuntu cells)"
+            echo
+            echo '```'
+            sed -n '/Coverage summary/,/^=*$/p' "${RUNNER_TEMP}/coverage.txt" | sed '1d;$d'
+            echo '```'
+            echo
+            echo "Full per-file table in the job log; HTML and lcov in the framework-coverage artifact."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: 💾 Upload framework coverage report
+        uses: actions/upload-artifact@v7
+        with:
+          name: framework-coverage
+          path: coverage/framework
+
   runner:
     uses: ./.github/workflows/template-runner.yaml
     with:

--- a/.github/workflows/template-suite.yaml
+++ b/.github/workflows/template-suite.yaml
@@ -83,6 +83,27 @@ jobs:
       - name: 🔍 Run Tests (linux)
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npm run test:${{ inputs.test_group }} --workspace=extester-test
+        env:
+          # Framework coverage: every Node process spawned from here (the
+          # ExTester/Mocha runner included) dumps V8 coverage into this folder
+          # on exit. The dumps are merged into one report by the `coverage`
+          # job in main.yml. Linux only - the merge needs identical absolute
+          # paths to remap the dumps, and the ubuntu runners share them.
+          NODE_V8_COVERAGE: ${{ runner.temp }}/v8-coverage
+
+      - name: ✂️ Trim V8 coverage dumps to framework code (linux)
+        if: ${{ !cancelled() && startsWith(matrix.os, 'ubuntu') }}
+        run: node .github/scripts/trim-v8-coverage.mjs "${RUNNER_TEMP}/v8-coverage" "${GITHUB_WORKSPACE}"
+
+      - name: 💾 Upload V8 coverage dumps (linux)
+        uses: actions/upload-artifact@v7
+        # Failing tests still produce valid coverage for the code they ran.
+        if: ${{ !cancelled() && startsWith(matrix.os, 'ubuntu') }}
+        with:
+          name: v8-coverage-${{ inputs.test_group }}-${{ matrix.label }}
+          path: ${{ runner.temp }}/v8-coverage
+          if-no-files-found: warn
+          retention-days: 3
 
       - name: 💾 Upload Screenshots and ChromeDriver logs
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

The dedicated 📊 Code Coverage workflow re-ran the whole UI suite (about ten minutes of ubuntu time) on every push and pull request, and what it measured was the sample extension in `tests/test-project`, not the framework. Its only output was an artifact nobody consumed.

This PR makes framework coverage a byproduct of the Main CI matrix and moves the sample-extension job to a nightly schedule:

- **`template-suite.yaml`**: the linux test step gets `NODE_V8_COVERAGE`, so the ExTester/Mocha runner process dumps V8 coverage on exit. A new step (`.github/scripts/trim-v8-coverage.mjs`) keeps only scripts under `packages/` before upload; one suite group went from 28 files / 31.75 MB to 1 file / 0.61 MB with a byte-identical c8 report. Dumps are uploaded from both ubuntu cells even when tests failed, because failing tests still yield valid coverage for the code they ran. Retention is 3 days.
- **`main.yml`**: a new `coverage` job waits for all suite groups, merges their dumps, runs `c8 report --config .github/c8-framework.json`, writes the summary block to the job summary and uploads `coverage/framework` (HTML + lcov) as the `framework-coverage` artifact. It is informational only: not part of the 🚦 Status Check and skipped only when the run was cancelled.
- **`.github/c8-framework.json`**: reports `packages/*/out/**` with source-map remapping to the TypeScript sources; `out/test/**` and `extester-runner` are excluded. It is deliberately **not** named `.c8rc*`: the `extest --coverage` feature discovers rc files by walking up from `tests/test-project`, and a root `.c8rc` would silently reconfigure that report.
- **`coverage.yml`**: still exercises `extest --coverage` against the sample extension, but only nightly (`0 3 * * *`) and on `workflow_dispatch`. Test failures remain non-blocking; the job now fails solely when no report was produced.

## Notes for reviewers

- The first Main CI run after merge is the baseline. A single group run locally gave 64% statements / 16% functions for `packages/*`; the full matrix will be higher.
- Linux cells only: the merge job rebuilds `packages/*/out` at the same absolute path to remap the dumps, and only the ubuntu runners share that path. macOS/Windows dumps would need path rewriting first.
- c8 merges per-process dumps itself; merging near-identical dumps shifts the branch denominator slightly, so expect small branch-count drift between runs.
- Fixes to the `extest --coverage` feature itself (out-of-project files in its report, `.c8rc` key handling, thresholds) are unrelated to CI and will come separately.

## Testing

- Local run on VS Code 1.135.0 with `NODE_V8_COVERAGE` set on the CLI process for one suite group, then `c8 report --config .github/c8-framework.json`: 151 files, all under `packages/*` and remapped to `.ts`, with no `tests/test-project`, VS Code or `node_modules` entries.
- Trim script verified: report from trimmed dumps is byte-identical to the untrimmed one.
- The merge loop and the job-summary extraction were dry-run under bash with real dump files (two group directories plus an empty one).
- Repo-wide `prettier --check` clean; all three workflows parse with js-yaml; `npm run test:unit` 84 passing. actionlint was not available locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
