### PR TITLE
docs: explain how coverage is collected and where the CI coverage reports live

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,12 +100,23 @@ code where a W3C-precise read is specifically wanted.
 | Locator XPaths | **Do not write XPath strings in tests.** Always use the page-objects locator API |
 | Element attributes | **Do not migrate `getAttribute()` to `getDomAttribute()`/`getDomProperty()`** — see the Page Object Model section |
 | Root dependencies | **Do not add runtime deps to the root `package.json`** — root is dev tooling only |
+| Coverage config | **Do not add a root `.c8rc*` / `.nycrc*` file** — `extest --coverage` discovers rc files by walking up from its cwd; the CI framework-coverage config is `.github/c8-framework.json`, passed with `--config` |
 
 ### VS Code version support policy
 
 ExTester maintains support for the **latest 3 stable VS Code releases** via a rolling window.
 This is automated — a CI workflow (`update-vscode-versions.yml`) opens PRs when new versions drop.
 Maintainers review, wait for CI green, and merge.
+
+### Coverage in CI
+
+Framework coverage of `packages/*` is a byproduct of the Main CI matrix: the ubuntu cells of
+each suite job run with `NODE_V8_COVERAGE` set, `.github/scripts/trim-v8-coverage.mjs` keeps only
+framework scripts, and the `coverage` job in `main.yml` merges the dumps with
+`c8 report --config .github/c8-framework.json` (job summary + `framework-coverage` artifact).
+It is informational and not part of the status check. `coverage.yml` separately exercises
+`extest --coverage` on the sample extension, nightly and on demand only. Neither requires
+passing tests — failing tests still produce valid coverage for the code they ran.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,15 @@ npm run test:build
 
 If you are adding a new feature, be sure to **write new tests** for it. If you navigate to the `tests/test-project/src/test` folder, you will find a test file structure that mirrors the source files. Put your new test into the appropriate existing file, or create a new one that follows the same structure.
 
+### Coverage
+
+Two workflows measure coverage, and neither needs the tests to pass: V8 writes its coverage data when a process exits, so failed tests still count for the code they ran.
+
+- **Framework coverage** (the `📊 Framework Coverage` job in [Main CI](../../actions/workflows/main.yml)): the ubuntu cells of every suite job collect V8 coverage of the ExTester runner process while the UI tests run, and one final job merges them into a report of how much of `packages/*` the tests exercise. The numbers are in that job's summary; the HTML and lcov report is the `framework-coverage` artifact. It is informational only and not part of the status check.
+- **Sample-extension coverage** (the [Code Coverage](../../actions/workflows/coverage.yml) workflow): runs `extest --coverage` against `tests/test-project` nightly and on demand, as a smoke test of the coverage feature itself. It fails only when no report is produced.
+
+The framework report is configured in `.github/c8-framework.json`. **Do not add a `.c8rc*` or `.nycrc*` file to the repository root**: `extest --coverage` discovers such files by walking up from the directory it runs in, so a root file would silently reconfigure the sample-extension report.
+
 ### Pull Requests
 
 Having made and tested your changes, we recommend committing them into a new branch:

--- a/docs-site/src/content/docs/guides/code-coverage.md
+++ b/docs-site/src/content/docs/guides/code-coverage.md
@@ -9,6 +9,17 @@ option when running tests via a CLI command
 
 Coverage can also be enabled with `"run": { "coverage": true }` in `extester.config.json` — see [Using a Config File](/vscode-extension-tester/guides/test-setup/#using-a-config-file).
 
+## How coverage is collected
+
+ExTester does not instrument your code. When coverage is enabled, the framework points Node's built-in [`NODE_V8_COVERAGE`](https://nodejs.org/api/cli.html#node_v8_coveragedir) at a temporary directory before VS Code starts, and every Node process launched from there — including the extension host that runs your extension — writes its raw V8 coverage into that directory when it exits. After the browser is closed, c8 converts those files into the report.
+
+A few consequences follow from this:
+
+- **Tests do not have to pass.** Coverage data is written at process exit regardless of the Mocha result, so failing tests still count for the code they ran.
+- **Your extension has to activate.** Files that were never loaded do not appear in the report by default (`all: false`). If the report is empty or unexpectedly small, check that the tests trigger one of your `activationEvents`.
+- **VS Code runs as an Extension Development Host**, with `--extensionDevelopmentPath` pointing at the directory you invoke `extest` from. The window title gets an `[Extension Development Host]` suffix, and when a VSIX is also installed (`-u`), the development copy takes precedence over it.
+- **Source maps are needed** for the report to show your TypeScript sources; without them c8 reports the compiled JavaScript.
+
 ## Configuration Options
 
 A configuration file can change the default behaviors of the c8 tool. The framework searches for c8 JSON configuration files named `.c8rc`, `.c8rc.json`, `.nycrc`, or `.nycrc.json`, starting from the directory you invoke `extest` from (`process.cwd()`), walking upwards. You can check out what options are supported in the [c8 documentation](https://github.com/bcoe/c8?tab=readme-ov-file#cli-options--configuration).
@@ -58,3 +69,7 @@ However, in special situations where you need to load a vsix file in your test, 
 When `-u` option is specified, the framework will build and install a vsix file prior to executing tests. After completing the test run, the framework uninstall the vsix file.
 Keep in mind that even when using the `-u` option, source codes will still be sourced directly from your
 project directory with code coverage enabled.
+
+## Coverage of ExTester itself
+
+If you are contributing to ExTester, the framework's own coverage is collected differently, as a byproduct of the Main CI test matrix, and is described in [CONTRIBUTING.md](https://github.com/redhat-developer/vscode-extension-tester/blob/main/CONTRIBUTING.md#coverage).


### PR DESCRIPTION
## Summary

Follow-up to #2492, which made framework coverage a byproduct of the Main CI matrix and moved the sample-extension coverage workflow to a nightly schedule, but did not update the documentation.

- **`docs-site` → Guides → Code Coverage**: new "How coverage is collected" section. Coverage comes from Node's `NODE_V8_COVERAGE` collector at process exit, so tests do not have to pass; the extension must activate to appear in the report; VS Code runs as an Extension Development Host with its visible side effects (window title suffix, development copy overriding an installed VSIX under `-u`); source maps are needed for TypeScript output. A closing section points contributors to CONTRIBUTING.md for the framework's own coverage.
- **`CONTRIBUTING.md`**: new "Coverage" subsection between "Test It" and "Pull Requests": what the `📊 Framework Coverage` job is, where its numbers and the `framework-coverage` artifact are, that it is informational only and not part of the status check, and that the Code Coverage workflow now runs nightly and on demand as a smoke test of `extest --coverage`. It also states the rule not to add a root `.c8rc*` / `.nycrc*` file, because `extest --coverage` discovers such files by walking up the directory tree.
- **`AGENTS.md`**: conventions-table row for the root rc-file hazard and a short "Coverage in CI" paragraph.

## Notes for reviewers

- README needs nothing: it carries no coverage badge and there is no service to back one.
- The guide still links to the full c8 option list and says nothing about thresholds; both are inaccurate today (only camelCase keys are applied, `check-coverage` is not enforced). That will be corrected together with the code change that fixes it, so it is intentionally not documented here.

## Testing

- `docs-site`: `npm ci --ignore-scripts && npm run build` (as in `deploy-docs.yml`) succeeds, 58 pages, starlight-links-validator reports all internal links valid; both new sections render on the built page.
- `prettier --check CONTRIBUTING.md` clean; `AGENTS.md` and `docs-site/` are excluded from Prettier by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
