### PR TITLE
fix(page-objects): replace Ctrl+A chord in setText() with selectAll command

### DIFF
--- a/packages/page-objects/src/components/editor/TextEditor.ts
+++ b/packages/page-objects/src/components/editor/TextEditor.ts
@@ -186,7 +186,9 @@ export class TextEditor extends Editor {
 		}
 		const inputarea = await this.findElement(TextEditor.locators.Editor.inputArea);
 		clipboard.writeSync(text);
-		await inputarea.sendKeys(Key.chord(TextEditor.ctlKey, 'a'), Key.chord(TextEditor.ctlKey, 'v'));
+		const bench = new Workbench();
+		await bench.executeCommand('editor.action.selectAll');
+		await inputarea.sendKeys(Key.chord(TextEditor.ctlKey, 'v'));
 		if (originalClipboard.length > 0) {
 			clipboard.writeSync(originalClipboard);
 		}


### PR DESCRIPTION
Change `TextEditor.setText` to use `editor.action.selectAll` command instead of the `Ctrl+A` keyboard chord for selecting all editor text before pasting, making it more stable.

Closes https://github.com/redhat-developer/vscode-extension-tester/issues/2510.

## Problem

Under certain timing or focus conditions the `Ctrl+A` chord in `sendKeys` does not fully suppress the literal `a` keypress, causing it to leak into the active editor buffer:

```ts
await inputarea.sendKeys(Key.chord(TextEditor.ctlKey, 'a'), Key.chord(TextEditor.ctlKey, 'v'));
```

This is the same root cause fixed for `getText()` in PR #2447.

## Fix

Replace the chord-based select-all with the VS Code command, then keep the paste chord (which has no `a` leak risk):

```ts
const bench = new Workbench();
await bench.executeCommand('editor.action.selectAll');
await inputarea.sendKeys(Key.chord(TextEditor.ctlKey, 'v'));
```

Before submitting your PR, please review the following checklist:

- [x] **CONSIDER** adding a new test if your PR resolves an issue.
- [x] **DO** keep pull requests small so they can be easily reviewed.
- [x] **DO** make sure tests pass.
- [x] **DO** make sure any public APIs changes are documented.
- [x] **DO** make sure not to introduce any compiler warnings.

Before merging the PR:

- [ ] **CHECK** continuous integration of `main` branch is green.
- [ ] **CHECK** pull request check job is green.
- [ ] **CHECK** all pull request questions/requests are resolved.
- [ ] **WAIT** till PR is approved by at least 1 committer.