### PR TITLE
build: scope js-yaml override to 4.x so extester tests js-yaml 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@types/chai": "^4.3.20",
         "@types/clone-deep": "^4.0.4",
         "@types/fs-extra": "^11.0.4",
-        "@types/js-yaml": "^4.0.9",
         "@types/mocha": "^10.0.10",
         "@types/node": "^26.4.0",
         "@types/selenium-webdriver": "^4.35.6",
@@ -2571,13 +2570,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
       "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-      "license": "MIT"
-    },
-    "node_modules/@types/js-yaml": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -13235,6 +13227,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "packages/extester/node_modules/js-yaml": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+      "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "packages/locators": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@types/chai": "^4.3.20",
     "@types/clone-deep": "^4.0.4",
     "@types/fs-extra": "^11.0.4",
-    "@types/js-yaml": "^4.0.9",
     "@types/mocha": "^10.0.10",
     "@types/node": "^26.4.0",
     "@types/selenium-webdriver": "^4.35.6",
@@ -64,7 +63,7 @@
     "axios": "^1.18.1",
     "brace-expansion": "^5.0.8",
     "diff": "9.0.0",
-    "js-yaml": "^4.3.0",
+    "js-yaml@^4": "^4.3.2",
     "pacote": "^21.5.1",
     "serialize-javascript": "7.0.7",
     "tar": "^7.5.22"

--- a/packages/extester/src/suite/runner.ts
+++ b/packages/extester/src/suite/runner.ts
@@ -27,6 +27,9 @@ import { logging } from 'selenium-webdriver';
 import * as os from 'node:os';
 import { Coverage } from '../util/coverage';
 
+/** YAML 1.2 core schema plus merge keys, matching how mocha parses .mocharc.yml */
+const MOCHARC_YAML_SCHEMA = yaml.CORE_SCHEMA.withTags(yaml.mergeTag);
+
 /**
  * Mocha runner wrapper
  */
@@ -216,7 +219,14 @@ export class VSRunner {
 			console.log(`Loading mocha configuration from ${file}`);
 			if (/\.(yml|yaml)$/.test(file)) {
 				try {
-					conf = yaml.load(fs.readFileSync(file, 'utf-8')) as Mocha.MochaOptions;
+					// js-yaml 5 throws on an empty stream and its default (YAML 1.2 core) schema no longer applies merge
+					// keys (`<<`). Keep the js-yaml 4 behaviour mocha itself still has: merge keys are honoured, and an
+					// empty or comment-only file means "no options".
+					const docs = yaml.loadAll(fs.readFileSync(file, 'utf-8'), { schema: MOCHARC_YAML_SCHEMA });
+					if (docs.length > 1) {
+						throw new Error('expected a single YAML document');
+					}
+					conf = (docs[0] as Mocha.MochaOptions | null | undefined) ?? {};
 				} catch (err) {
 					if (isExplicit) {
 						throw new Error(`Failed to parse mocha configuration ${file}: ${err}`);

--- a/packages/extester/src/test/runner.test.ts
+++ b/packages/extester/src/test/runner.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License", destination); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { VSRunner } from '../suite/runner';
+import { ReleaseQuality } from '../util/codeUtil';
+
+/**
+ * Writes a mocha YAML config with the given content into a fresh temp dir and returns its path.
+ */
+function writeMocharc(content: string, name = '.mocharc.yml'): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'extester-runner-test-'));
+	const file = path.join(dir, name);
+	fs.writeFileSync(file, content, 'utf8');
+	return file;
+}
+
+/**
+ * Loads a mocha config file through VSRunner's private loader so the assertions target exactly
+ * what `new Mocha(...)` receives.
+ */
+function loadMochaConfig(file: string): Mocha.MochaOptions {
+	const runner = new VSRunner('/dev/null', '1.100.0', ReleaseQuality.Stable);
+	return runner['loadConfig'](file);
+}
+
+describe('VSRunner mocha config loading (YAML)', () => {
+	const tmpDirs: string[] = [];
+
+	afterEach(() => {
+		for (const dir of tmpDirs.splice(0)) {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	function mocharc(content: string, name?: string): string {
+		const file = writeMocharc(content, name);
+		tmpDirs.push(path.dirname(file));
+		return file;
+	}
+
+	it('parses common mocha options from .mocharc.yml', () => {
+		const file = mocharc(['timeout: 5000', 'require: ts-node/register', 'spec:', '  - out/**/*.js', 'bail: true', 'slow: 75', 'retries: 2', ''].join('\n'));
+		const conf = loadMochaConfig(file);
+		assert.deepStrictEqual(conf, {
+			timeout: 5000,
+			require: 'ts-node/register',
+			spec: ['out/**/*.js'],
+			bail: true,
+			slow: 75,
+			retries: 2,
+		});
+	});
+
+	it('accepts the .yaml extension too', () => {
+		const file = mocharc('timeout: 1234\n', '.mocharc.yaml');
+		assert.deepStrictEqual(loadMochaConfig(file), { timeout: 1234 });
+	});
+
+	it('keeps YAML 1.2 scalar semantics (yes/on stay strings, like mocha itself)', () => {
+		const file = mocharc('bail: yes\ncolor: on\nparallel: true\n');
+		assert.deepStrictEqual(loadMochaConfig(file), { bail: 'yes', color: 'on', parallel: true });
+	});
+
+	it('honours YAML merge keys (<<) the same way mocha does', () => {
+		const file = mocharc(['defaults: &defaults', '  timeout: 3000', '  retries: 1', '<<: *defaults', 'bail: true', ''].join('\n'));
+		const conf = loadMochaConfig(file);
+		assert.deepStrictEqual(conf, { defaults: { timeout: 3000, retries: 1 }, timeout: 3000, retries: 1, bail: true });
+		assert.ok(!('<<' in conf), 'merge key must be applied, not kept as a literal "<<" key');
+	});
+
+	it('treats an empty config file as "no options" instead of failing', () => {
+		const file = mocharc('');
+		assert.deepStrictEqual(loadMochaConfig(file), {});
+	});
+
+	it('treats a comment-only config file as "no options" instead of failing', () => {
+		const file = mocharc('# mocha options go here\n');
+		assert.deepStrictEqual(loadMochaConfig(file), {});
+	});
+
+	it('rejects a multi-document YAML config when the config was passed explicitly', () => {
+		const file = mocharc('timeout: 1000\n---\ntimeout: 2000\n');
+		assert.throws(() => loadMochaConfig(file), /Failed to parse mocha configuration/);
+	});
+
+	it('still rejects malformed YAML when the config was passed explicitly', () => {
+		const file = mocharc('timeout: [unclosed\n');
+		assert.throws(() => loadMochaConfig(file), /Failed to parse mocha configuration/);
+	});
+});


### PR DESCRIPTION
## Why

The root `overrides` entry `"js-yaml": "^4.3.0"` was added in #2427 as a security floor (GHSA-52cp-r559-cp3m, 4.x < 4.3.0) for the transitive consumers lerna, mocha, cosmiconfig and rc-config-loader. The same commit bumped `packages/extester` to js-yaml `^5.x`, but because the override key is unqualified npm applied it to extester's edge too. Result:

- the monorepo has resolved js-yaml 4.3.0 → 4.3.2 ever since, so build, unit tests and UI tests never ran against js-yaml 5 while npm consumers get 5.x;
- `npm ls --all` reports `js-yaml@4.3.2 deduped invalid: "^5.4.1" from packages/extester`;
- Dependabot kept opening the same "bump js-yaml from 4.3.2 to 5.4.1" PR (#2479, #2482, #2496) and each merge only rewrote the spec; the manual lockfile edit in #2480 changed nothing either.

Nothing in the tree needs js-yaml < 5 for compatibility, but lerna 10.0.1 pins `js-yaml@4.3.0` exactly and that version is flagged high by GHSA-5p4m-2wfm-xmqj, so a floor for the 4.x edges is still needed.

## What

- **package.json**: override key is now `"js-yaml@^4": "^4.3.2"`, so it only rewrites 4.x edges and leaves extester's `^5.4.1` alone. Removed `@types/js-yaml`; v5 ships its own types.
- **package-lock.json**: extester gets a nested js-yaml 5.4.1; lerna, mocha, cosmiconfig, rc-config-loader and textlint stay on 4.3.2.
- **runner.ts**: js-yaml 5's default YAML 1.2 core schema turns `<<:` into a literal key and `load()` throws on an empty stream. Switched to `loadAll` with `CORE_SCHEMA.withTags(mergeTag)` so `.mocharc.yml` behaves as it did with v4 and as it still does in mocha itself: merge keys applied, empty or comment-only file means "no options", multi-document files still rejected.
- **runner.test.ts**: unit tests covering those cases. The merge-key and empty-file tests fail on js-yaml 5 without the runner change.

## Verification

- `npm ls --all 2>&1 | grep -i invalid` no longer mentions js-yaml.
- `npm run test:unit`: all passing; full extester build passes and the compiled runner loads against 5.4.1.
- Re-resolving the lock with the pinned npm 10.9.2 gives identical js-yaml placement, so the `name@range` override key form is safe for CI.
- No Dependabot `ignore` rule needed: the tree now agrees on 5.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
