### PR TITLE
chore: remove legacy .eslintignore left behind by the ESLint 9 migration

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,0 @@
-.eslintrc.json


### PR DESCRIPTION
## Summary

Deletes the root `.eslintignore`. Its only line was `.eslintrc.json`, which no longer exists: #1558 replaced it with the flat `eslint.config.js`, but left the ignore file behind. Flat config never reads `.eslintignore`, so since ESLint 9 the file has had no effect on what gets linted. Its only remaining effect was this warning on every root-level ESLint invocation:

```
ESLintIgnoreWarning: The ".eslintignore" file is no longer supported. Switch to using the "ignores" property in "eslint.config.js"
```

Nothing is added to the `ignores` array, because the only entry pointed at a file that does not exist. The existing `ignores` entry for compiled test files is untouched.

## Verification

- `grep -rn eslintignore` across the tree (excluding `node_modules` and `.git`) finds no other references, including CI workflows, prettier config, and docs.
- `npx eslint --print-config packages/page-objects/src/index.ts` no longer prints the warning.
- `npm run build` for each workspace (`@redhat-developer/locators`, `@redhat-developer/page-objects`, `vscode-extension-tester`, `extester-runner`, `extester-test`) passes; each runs `eslint --fix --fix-type layout` and none emits the warning.

---

Before submitting your PR, please review the following checklist:

- [ ] **CONSIDER** adding a new test if your PR resolves an issue.
- [x] **DO** keep pull requests small so they can be easily reviewed.
- [x] **DO** make sure tests pass.
- [x] **DO** make sure any public APIs changes are documented.
- [x] **DO** make sure not to introduce any compiler warnings.

Before merging the PR:

- [ ] **CHECK** continuous integration of `main` branch is green.
- [ ] **CHECK** pull request check job is green.
- [ ] **CHECK** all pull request questions/requests are resolved.
- [ ] **WAIT** till PR is approved by at least 1 committer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
